### PR TITLE
More configuration tweaks.

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -60,8 +60,6 @@ RUN mkdir /galaxy-central/tool_deps
 # Fetching all Galaxy python dependencies
 RUN python scripts/fetch_eggs.py
 
-RUN sed -i 's|debug = True|debug = False|g' /galaxy-central/config/galaxy.ini
-
 ENV GALAXY_CONFIG_DATABASE_CONNECTION postgresql://galaxy:galaxy@localhost:5432/galaxy
 ENV GALAXY_CONFIG_TOOL_DEPENDENCY_DIR ./tool_deps
 ENV GALAXY_CONFIG_ADMIN_USERS admin@galaxy.org


### PR DESCRIPTION
Target next-stable instead of default ahead of next release and do not explicitly set database in configuration file - should be fixed now.
