### PR TITLE
Add watchdog to Galaxy's virtualenv.

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -122,6 +122,8 @@ RUN /usr/sbin/create-munge-key
 RUN mkdir -p /var/run/munge && chown root:root /var/lib/munge/ /var/log/munge/ /var/run/munge /etc/munge/ /etc/munge/munge.key
 ADD ./configure_slurm.py /usr/sbin/configure_slurm.py
 
+# Add optional watchdog dependency to Galaxy's environment.
+RUN . /root/venv/bin/activate && pip install watchdog
 
 # Expose port 80 to the host
 EXPOSE :80


### PR DESCRIPTION
Assists with developing new tools in Galaxy. If I could issue pull requests to `eggs.galaxyproject.org` instead I would - but I cannot - so I will see if you will accept this instead :). 
