### PR TITLE
Move the welcome.html page into `/etc/galaxy/`

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -116,6 +116,7 @@ GALAXY_CONFIG_TOOLFORM_UPGRADE=True \
 GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://$HOST_IP/ \
 GALAXY_CONFIG_SANITIZE_ALL_HTML=False \
 GALAXY_CONFIG_TOOLFORM_UPGRADE=True \
+GALAXY_CONFIG_WELCOME_URL=$GALAXY_CONFIG_DIR/welcome.html \
 GALAXY_CONFIG_OVERRIDE_DEBUG=False
 
 # Define the default postgresql database path
@@ -127,8 +128,8 @@ PG_DATA_DIR_HOST=/export/postgresql/9.3/main/
 RUN  cd /galaxy-central/lib/galaxy/web/proxy/js && npm install
 
 # Container Style
-ADD GalaxyDocker.png /galaxy-central/static/welcome/GalaxyDocker.png
-ADD welcome.html /galaxy-central/static/welcome.html
+ADD GalaxyDocker.png $GALAXY_CONFIG_DIR/welcome_image.png
+ADD welcome.html $GALAXY_CONFIG_DIR/welcome.html
 
 # Switch back to User root
 USER root

--- a/galaxy/export_user_files.py
+++ b/galaxy/export_user_files.py
@@ -45,6 +45,15 @@ if __name__ == "__main__":
     if os.path.exists( '/export/.distribution_config/' ):
         shutil.rmtree( '/export/.distribution_config/' )
     shutil.copytree( '/galaxy-central/config/', '/export/.distribution_config/' )
+
+    # Copy all files starting with "welcome"
+    # This enables a flexible start page design.
+    for filename in os.listdir('/export/'):
+        if filename.startswith('welcome'):
+            export_file = os.path.join( '/export/', filename)
+            image_file = os.path.join('/etc/galaxy/', filename)
+            shutil.copy(export_file, image_file)
+
     if not os.path.exists( '/export/galaxy-central/' ):
         os.makedirs("/export/galaxy-central/")
         os.chown( "/export/galaxy-central/", int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )

--- a/galaxy/welcome.html
+++ b/galaxy/welcome.html
@@ -3,18 +3,19 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <link rel="stylesheet" href="style/base.css" type="text/css" />
+    <!-- If you want to use Galaxy css or JS files/libraries the path needs to start with '/static/' -->
+    <link rel="stylesheet" href="/static/style/base.css" type="text/css" />
 </head>
 <body>
     <div class="document">
         <div class="donemessagelarge">
             <strong>Hello world! Your Galaxy Docker container is running...</strong>
             <hr>
-            To customize this page edit <code>static/welcome.html</code>
+            To customize this page you can create a <code>welcome.html</code> page in your directory mounted to <code>/export</code>.
         </div>
         <br/>
         <div align=center>
-        <img src="welcome/GalaxyDocker.png"/>
+        <img src="./welcome_image.png"/>
         </div>
         <br>
         <hr/>


### PR DESCRIPTION
Override it as soon as we detect a new one under `/export/`. In fact this holds for all files starting with "welcome", e.g. images that you want to use in your start page.

This PR depends on https://github.com/galaxyproject/ansible-galaxy-extras/pull/5