### PR TITLE
Address #42.

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV GALAXY_RELEASE=v15.03 \
+ENV GALAXY_RELEASE=release_15.03_docker \
+GALAXY_REPO=https://github.com/jmchilton/galaxy/ \
 GALAXY_ROOT=/galaxy-central \
 GALAXY_CONFIG_DIR=/etc/galaxy
 
@@ -47,7 +48,7 @@ RUN groupadd -r $GALAXY_USER -g $GALAXY_GID && \
     gpasswd -a $GALAXY_USER docker
 
 # Download latest stable release of Galaxy.
-RUN mkdir $GALAXY_ROOT && wget -q -O - https://github.com/galaxyproject/galaxy/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_ROOT
+RUN mkdir $GALAXY_ROOT && wget -q -O - $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_ROOT
 
 # TODO: ensure virtualenv as part of galaxy role
 RUN su $GALAXY_USER -c "virtualenv $GALAXY_VIRTUALENV"

--- a/galaxy/export_user_files.py
+++ b/galaxy/export_user_files.py
@@ -56,16 +56,24 @@ if __name__ == "__main__":
             image_file = os.path.join('/etc/galaxy/', filename)
             shutil.copy(export_file, image_file)
 
-    for config in [ 'galaxy.ini', 'job_conf.xml' ]:
-        export_config = os.path.join( '/export/galaxy-central/config', config )
-        if os.path.exists(export_config):
-            image_config = os.path.join('/etc/galaxy/', config)
-            shutil.copy(export_config, image_config)
-
     if not os.path.exists( '/export/galaxy-central/' ):
         os.makedirs("/export/galaxy-central/")
         os.chown( "/export/galaxy-central/", int(os.environ['GALAXY_UID']), int(os.environ['GALAXY_GID']) )
+
     change_path('/galaxy-central/config/')
+
+    # copy image defaults to config/<file>.docker_sample to base derivatives on,
+    # and if there is a realized version of these files in the export directory
+    # replace Galaxy's copy with these. Use symbolic link instead of copying so
+    # deployer can update and reload Galaxy and changes will be reflected.
+    for config in [ 'galaxy.ini', 'job_conf.xml' ]:
+        image_config = os.path.join('/etc/galaxy/', config)
+        export_config = os.path.join( '/export/galaxy-central/config', config )
+        export_sample = export_config + ".docker_sample"
+        shutil.copy(image_config, export_sample)
+        if os.path.exists(export_config):
+            subprocess.call('ln -s -f %s %s' % (export_config, image_config), shell=True)
+
     change_path('/galaxy-central/integrated_tool_panel.xml')
     change_path('/galaxy-central/display_applications/')
     change_path('/galaxy-central/tool_deps/')

--- a/galaxy/export_user_files.py
+++ b/galaxy/export_user_files.py
@@ -47,6 +47,7 @@ if __name__ == "__main__":
         shutil.rmtree( '/export/.distribution_config/' )
     shutil.copytree( '/galaxy-central/config/', '/export/.distribution_config/' )
 
+
     # Copy all files starting with "welcome"
     # This enables a flexible start page design.
     for filename in os.listdir('/export/'):
@@ -54,6 +55,12 @@ if __name__ == "__main__":
             export_file = os.path.join( '/export/', filename)
             image_file = os.path.join('/etc/galaxy/', filename)
             shutil.copy(export_file, image_file)
+
+    for config in [ 'galaxy.ini', 'job_conf.xml' ]:
+        export_config = os.path.join( '/export/galaxy-central/config', config )
+        if os.path.exists(export_config):
+            image_config = os.path.join('/etc/galaxy/', config)
+            shutil.copy(export_config, image_config)
 
     if not os.path.exists( '/export/galaxy-central/' ):
         os.makedirs("/export/galaxy-central/")

--- a/galaxy/export_user_files.py
+++ b/galaxy/export_user_files.py
@@ -10,6 +10,7 @@ else:
 PG_DATA_DIR_HOST = os.environ.get("PG_DATA_DIR_HOST", "/export/postgresql/9.3/main/")
 PG_CONF = '/etc/postgresql/9.3/main/postgresql.conf'
 
+
 def change_path( src ):
     """
         src will be copied to /export/`src` and a symlink will be placed in src pointing to /export/
@@ -81,7 +82,7 @@ if __name__ == "__main__":
         # copy the postgresql data folder to the new location
         subprocess.call('cp -R %s/* %s' % (PG_DATA_DIR_DEFAULT, PG_DATA_DIR_HOST), shell=True)
         # copytree needs an non-existing dst dir, how annoying :(
-        #shutil.copytree(PG_DATA_DIR_DEFAULT, PG_DATA_DIR_HOST)
+        # shutil.copytree(PG_DATA_DIR_DEFAULT, PG_DATA_DIR_HOST)
         subprocess.call('chown -R postgres:postgres /export/postgresql/', shell=True)
         subprocess.call('chmod -R 0755 /export/', shell=True)
         subprocess.call('chmod -R 0700 %s' % PG_DATA_DIR_HOST, shell=True)
@@ -91,4 +92,3 @@ if __name__ == "__main__":
     new_data_directory = "'%s'" % PG_DATA_DIR_HOST
     cmd = 'sed -i "s|data_directory = .*|data_directory = %s|g" %s' % (new_data_directory, PG_CONF)
     subprocess.call(cmd, shell=True)
-


### PR DESCRIPTION
 - Symbolically link in ``/export/galaxy-central/config/{{galaxy.ini,job_conf.xml}}`` if these files are found.
 - Drop latest docker container variants of these files into that directory with suffix ``.docker_sample`` for deployers to base derivatives on.
 - Target my ``release_15.03_docker`` branch - with additions allowing dynamic control of ``job_conf.xml`` properties using environment variables without modifying the file itself. I will setup a jenkins job to rebase it periodically against ``release_15.03`` so it automatically gets updates (the same way I keep my fork up to date - https://github.com/jmchilton/galaxy).

