### PR TITLE
Adding default PYTHONPATH so child docker processes will be able to find galaxy related libraries

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -176,7 +176,7 @@ EXPOSE :9002
 
 # We need to set $HOME for some Tool Shed tools (e.g Perl libs with $HOME/.cpan)
 ENV HOME /home/galaxy
-
+ENV PYTHONPATH /galaxy-central/lib/
 # Mark folders as imported from the host.
 VOLUME ["/export/", "/data/", "/var/lib/docker"]
 


### PR DESCRIPTION
My setup involves using the docker_default_container_id parameter in job_conf.xml, to process jobs in child docker containers. I use the same image as the launched docker-galaxy-stable, but processes don't seem to be able to find the galaxy libraries. The __SET_METADATA__ tool fails because 

```
Traceback (most recent call last):
  File "/export/galaxy-central/database/job_working_directory/000/100/tmp0wY16_", line 1, in 
    from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()
ImportError: No module named galaxy_ext.metadata.set_metadata
```

Simply adding a default PYTHONPATH that points to the /galaxy-central/lib/ fixes the problem.