### PR TITLE
Add a switch to enable the installation from TTS; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ For this we need to be able to launch Docker containers inside our Galaxy Docker
 
 The port 8800 is the proxy port that is used to handle Interactive Environments. ``--privileged`` is needed to start docker containers inside docker.
 
+Using passive mode FTP
+----------------------
+
+By default, FTP servers running inside of docker containers are not accessible via passive mode FTP, due to not being able to expose extra ports. To circumvent this, you can use the `--net=host` option to allow Docker to directly open ports on the host server:
+
+  ```bash
+  docker run -d --net=host -v /home/user/galaxy_storage/:/export/ bgruening/galaxy-stable
+  ```
+
+Note that there is no need to specifically bind individual ports (e.g., `-p 80:80`).
+
 Using Parent docker
 -------------------
 On some linux distributions, Docker-In-Docker can run into issues (such as running out of loopback interfaces). If this is an issue, you can use a 'legacy' mode that use a docker socket for the parent docker installation mounted inside the container. To engage, set the environmental variable `DOCKER_PARENT`
@@ -116,6 +127,11 @@ You can and should overwrite these during launching your container:
     -e "GALAXY_CONFIG_BRAND='My own Galaxy flavour'" \
     bgruening/galaxy-stable
   ```
+
+Note that if you would like to run any of the [cleanup scripts](https://wiki.galaxyproject.org/Admin/Config/Performance/Purge%20Histories%20and%20Datasets), you will need to add the following to `/export/galaxy-central/config/galaxy.ini`:
+
+    database_connection = postgresql://galaxy:galaxy@localhost:5432/galaxy
+    file_path = /export/galaxy-central/database/files 
 
 Personalize your Galaxy
 -----------------------

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -166,6 +166,9 @@ ADD ./startup.sh /usr/bin/startup
 ADD install_repo_wrapper.sh /usr/bin/install-repository
 RUN chmod +x /usr/bin/install-repository /usr/bin/startup
 
+# Activate additional Tool Sheds
+ADD ./tool_sheds_conf.xml $GALAXY_HOME/tool_sheds_conf.xml
+
 # This needs to happen here and not above, otherwise the Galaxy start
 # (without running the startup.sh script) will crash because integrated_tool_panel.xml could not be found.
 ENV GALAXY_CONFIG_INTEGRATED_TOOL_PANEL_CONFIG /export/galaxy-central/integrated_tool_panel.xml
@@ -179,7 +182,7 @@ EXPOSE :8800
 EXPOSE :9002
 
 # We need to set $HOME for some Tool Shed tools (e.g Perl libs with $HOME/.cpan)
-ENV HOME /home/galaxy
+ENV HOME $GALAXY_HOME
 ENV PYTHONPATH /galaxy-central/lib/
 # Mark folders as imported from the host.
 VOLUME ["/export/", "/data/", "/var/lib/docker"]

--- a/galaxy/startup.sh
+++ b/galaxy/startup.sh
@@ -7,6 +7,13 @@ cd /galaxy-central/
 umount /var/lib/docker
 python /usr/local/bin/export_user_files.py $PG_DATA_DIR_DEFAULT
 
+# Enable Test Tool Shed
+if [ "x$ENABLE_TTS_INSTALL" != "x" ]
+    then
+        echo "Enable installation from the Test Tool Shed."
+        export GALAXY_CONFIG_TOOL_SHEDS_CONFIG_FILE=$GALAXY_HOME/tool_sheds_conf.xml
+fi
+
 #Copy or link the slurm/munge config files
 if [ -e /export/slurm.conf ]
 then


### PR DESCRIPTION
This was deactivated in the current Galaxy stable. 
For Galaxy flavours, especially for testing, this is still useful and can now be activated by setting the `ENABLE_TTS_INSTALL`.