### PR TITLE
Support external Slurm-based clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ It is often convenient to configure Galaxy to use a high-performance cluster for
 
 Appropriate `munge.key` and `slurm.conf` files must be copied to the `/export` mount point accessible to Galaxy. This must be done regardless of which Slurm daemons are running within Docker. At start, symbolic links will be created to these files from `/etc`, allowing the various Slurm functions to communicate properly with your cluster. In such cases, there's no reason to run `slurmctld`, the Slurm controller daemon, from within Docker, so specify `-e "NONUSE=slurmctld"`. Unless you would like to also use Slurm (rather than the local job runner) to run jobs within the Docker container, then alternatively specify `-e "NONUSE=slurmctld,slurmd"`.
 
+Importantly, Slurm relies on a shared filesystem between the Docker container and the execution nodes. To allow things to function correctly, each of the execution nodes will need `/export` and `/galaxy-central` directories to point to the appropriate places. Suppose you ran the following command to start the Docker image:
+
+    docker run -d -e "NONUSE=slurmd,slurmctld" -p 80:80 -v /data/galaxy:/export bgruening/galaxy-stable
+
+You would then need the following symbolic links on each of the nodes:
+
+ 1. `/export` -> `/data/galaxy`
+ 2. `/galaxy-central` -> `/data/galaxy/galaxy-central`
+
 A brief note is in order regarding the version of Slurm installed. This Docker image uses Ubuntu 14.04 as its base image. The version of Slurm in the Unbuntu 14.04 repository is 2.6.5 and that is what is installed in this image. If your cluster is using an incompatible version of Slurm then you will likely need to modify this Docker image.
 
 Extending the Docker Image

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ The Galaxy welcome screen can be changed by providing a `welcome.hml` page in `/
 Deactivating services
 ---------------------
 
-Non-essential services can be deactivated during startup. Set the environment variable `NONUSE` to a comma separated list of services. Currently, `nodejs`, `proftp` and `reports` are supported.
+Non-essential services can be deactivated during startup. Set the environment variable `NONUSE` to a comma separated list of services. Currently, `nodejs`, `proftp`, `reports`, `slurmd` and `slurmctld` are supported.
 
   ```bash
   docker run -d -p 8080:80 -p 8021:21 -p 9002:9002 \
-    -e "NONUSE=nodejs,proftp,reports" bgruening/galaxy-stable
+    -e "NONUSE=nodejs,proftp,reports,slurmd,slurmctld" bgruening/galaxy-stable
   ```
 
 A graphical user interface, to start and stop your services, is available on port `9002` if you run your container like above.
@@ -152,6 +152,18 @@ In addition you can access the supersisord webinterface on port `9002` and get a
   ```sh
   docker run -d -p 8080:80 -p 8021:21 -p 9002:9002 -e "GALAXY_LOGGING=full" bgruening/galaxy-stable
   ```
+
+Using an external Slurm cluster
+-------------------------------
+
+It is often convenient to configure Galaxy to use a high-performance cluster for running jobs. To do so, two files are required:
+
+ 1. munge.key
+ 2. slurm.conf
+
+Appropriate `munge.key` and `slurm.conf` files must be copied to the `/export` mount point accessible to Galaxy. This must be done regardless of which Slurm daemons are running within Docker. At start, symbolic links will be created to these files from `/etc`, allowing the various Slurm functions to communicate properly with your cluster. In such cases, there's no reason to run `slurmctld`, the Slurm controller daemon, from within Docker, so specify `-e "NONUSE=slurmctld"`. Unless you would like to also use Slurm (rather than the local job runner) to run jobs within the Docker container, then alternatively specify `-e "NONUSE=slurmctld,slurmd"`.
+
+A brief note is in order regarding the version of Slurm installed. This Docker image uses Ubuntu 14.04 as its base image. The version of Slurm in the Unbuntu 14.04 repository is 2.6.5 and that is what is installed in this image. If your cluster is using an incompatible version of Slurm then you will likely need to modify this Docker image.
 
 Extending the Docker Image
 ==========================

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -69,7 +69,7 @@ RUN ansible-playbook /tmp/ansible/provision.yml \
     --extra-vars galaxy_config_dir=$GALAXY_CONFIG_DIR \
     --extra-vars galaxy_job_conf_path=$GALAXY_CONFIG_JOB_CONFIG_FILE \
     --extra-vars galaxy_job_metrics_conf_path=$GALAXY_CONFIG_JOB_METRICS_CONFIG_FILE \
-    --extra-vars supervisor_manage_slurm=false \
+    --extra-vars supervisor_manage_slurm="" \
     --tags=galaxyextras -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -69,6 +69,7 @@ RUN ansible-playbook /tmp/ansible/provision.yml \
     --extra-vars galaxy_config_dir=$GALAXY_CONFIG_DIR \
     --extra-vars galaxy_job_conf_path=$GALAXY_CONFIG_JOB_CONFIG_FILE \
     --extra-vars galaxy_job_metrics_conf_path=$GALAXY_CONFIG_JOB_METRICS_CONFIG_FILE \
+    --extra-vars supervisor_manage_slurm=false \
     --tags=galaxyextras -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/galaxy/startup.sh
+++ b/galaxy/startup.sh
@@ -48,12 +48,12 @@ function start_supervisor {
     if [[ $NONUSE != *"slurmd"* ]]
     then
         echo "Starting slurmd"
-        supervisorctl start slurmd
+        /usr/sbin/slurmd -D -L /home/galaxy/slurmd.log
     fi
     if [[ $NONUSE != *"slurmctld"* ]]
     then
         echo "Starting slurmctld"
-        supervisorctl start slurmctld
+        /usr/sbin/slurmctld -D -L /home/galaxy/slurmctld.log
     fi
 }
 

--- a/galaxy/startup.sh
+++ b/galaxy/startup.sh
@@ -45,15 +45,15 @@ function start_supervisor {
         echo "Starting nodejs"
         supervisorctl start galaxy:galaxy_nodejs_proxy
     fi
-    if [[ $NONUSE != *"slurmd"* ]]
-    then
-        echo "Starting slurmd"
-        /usr/sbin/slurmd -D -L /home/galaxy/slurmd.log
-    fi
     if [[ $NONUSE != *"slurmctld"* ]]
     then
         echo "Starting slurmctld"
-        /usr/sbin/slurmctld -D -L /home/galaxy/slurmctld.log
+        /usr/sbin/slurmctld -L /home/galaxy/slurmctld.log
+    fi
+    if [[ $NONUSE != *"slurmd"* ]]
+    then
+        echo "Starting slurmd"
+        /usr/sbin/slurmd -L /home/galaxy/slurmd.log
     fi
 }
 


### PR DESCRIPTION
This should allow using an external Slurm-based cluster from within the Docker container. `munge.key` and `slurm.conf` can now be placed in `/export` and the Docker image will then use them. `slurmd` and `slurmctld` can now be disabled with environment variables. Note that if you're actually using an external cluster, you probably don't need any Slurm daemons running (you will need the two configuration files though!).