### PR TITLE
delay starting Galaxy until database is up

### DIFF
--- a/galaxy/install_repo_wrapper.sh
+++ b/galaxy/install_repo_wrapper.sh
@@ -1,8 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 # start Galaxy
 service postgresql start
 install_log='galaxy_install.log'
+
+# wait for database to finish starting up
+STATUS=$(psql 2>&1)   
+while [[ ${STATUS} =~ "starting up" ]]
+do
+  echo "waiting for database: $STATUS"
+  STATUS=$(psql 2>&1)  
+  sleep 1
+done
+
+echo "starting Galaxy"
 sudo -E -u galaxy ./run.sh --daemon --log-file=$install_log --pid-file=galaxy_install.pid
 
 galaxy_install_pid=`cat galaxy_install.pid`


### PR DESCRIPTION
Monitor the psql process to see when the database is completely finished starting up before starting Galaxy. Fixes the error: "OperationalError: (psycopg2.OperationalError) FATAL:  the database system is starting up".