### PR TITLE
Install latest version of setuptools into Galaxy venv

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -94,6 +94,8 @@ RUN mkdir $GALAXY_ROOT/tool_deps
 
 # Fetching all Galaxy python dependencies
 RUN . $GALAXY_VIRTUALENV/bin/activate && python scripts/fetch_eggs.py -c $GALAXY_CONFIG_FILE && python scripts/fetch_eggs.py -e drmaa -c $GALAXY_CONFIG_FILE
+# Installing latest version of setuptools
+RUN . $GALAXY_VIRTUALENV/bin/activate && pip install setuptools --upgrade
 
 # Updating genome informations from UCSC
 #RUN export GALAXY=/galaxy-central && sh ./cron/updateucsc.sh.sample


### PR DESCRIPTION
This is needed for a few Python packages, like `mock` which is a dependency of matplotlib.
I hope this has no negative effect of other libraries and installations. 
Its really time to make tools Python tools depended on their own Python version.

xref: https://github.com/galaxyproject/tools-iuc/issues/289