### PR TITLE
Use Ansible for installing tools during testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ services:
 env:
   - TOX_ENV=py27
 
+git:
+  submodules: false
+
 before_install:
   - GALAXY_TRAVIS_USER=galaxy
   - GALAXY_UID=1450
@@ -21,6 +24,7 @@ before_install:
   - BIOBLEND_GALAXY_URL=http://localhost:8080
   - TEST_TOOLSET_URL=https://raw.githubusercontent.com/afgane/docker-galaxy-stable/dev/galaxy/test_toolset.yml
 
+  - git submodule update --init --recursive
   - sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID
   - sudo useradd -u $GALAXY_UID -r -g $GALAXY_TRAVIS_USER -d $GALAXY_HOME -p travis_testing -c "Galaxy user" $GALAXY_TRAVIS_USER
   - sudo mkdir $GALAXY_HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - cd $GALAXY_HOME
   - sudo su $GALAXY_TRAVIS_USER -c 'wget https://github.com/galaxyproject/bioblend/archive/v0.7.0.tar.gz'
   - sudo su $GALAXY_TRAVIS_USER -c 'tar xfz v0.7.0.tar.gz'
-  - sudo su $GALAXY_TRAVIS_USER -c 'wget --output-document ~/ansible/test_toolset.yml $TEST_TOOLSET_URL'
+  - sudo su $GALAXY_TRAVIS_USER -c "wget --output-document ~/ansible/test_toolset.yml $TEST_TOOLSET_URL"
 
 install:
   - cd $GALAXY_HOME/bioblend-0.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - GALAXY_USER_PASSWD=admin
   - BIOBLEND_GALAXY_API_KEY=admin
   - BIOBLEND_GALAXY_URL=http://localhost:8080
+  - TEST_TOOLSET_URL=https://raw.githubusercontent.com/afgane/docker-galaxy-stable/dev/galaxy/test_toolset.yml
 
   - sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID
   - sudo useradd -u $GALAXY_UID -r -g $GALAXY_TRAVIS_USER -d $GALAXY_HOME -p travis_testing -c "Galaxy user" $GALAXY_TRAVIS_USER
@@ -37,6 +38,7 @@ before_install:
   - cd $GALAXY_HOME
   - sudo su $GALAXY_TRAVIS_USER -c 'wget https://github.com/galaxyproject/bioblend/archive/v0.7.0.tar.gz'
   - sudo su $GALAXY_TRAVIS_USER -c 'tar xfz v0.7.0.tar.gz'
+  - sudo su $GALAXY_TRAVIS_USER -c 'wget --output-document ~/ansible/test_toolset.yml $TEST_TOOLSET_URL'
 
 install:
   - cd $GALAXY_HOME/bioblend-0.7.0
@@ -48,4 +50,4 @@ script:
   # Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
   # this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
   - sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH && cd $GALAXY_HOME/bioblend-0.7.0 && tox -e $TOX_ENV"
-  - docker run galaxy-docker/test  bash -c 'install-repository "--url https://toolshed.g2.bx.psu.edu -o iuc --name bedtools --panel-section-name 'BEDTools'"'
+  - docker run galaxy-docker/test bash -c 'install-tools ~/ansible/test_toolset.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ script:
   # Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
   # this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
   - sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH && cd $GALAXY_HOME/bioblend-0.7.0 && tox -e $TOX_ENV"
-  - docker run galaxy-docker/test bash -c "wget --output-document /tmp/test_toolset.yml $TEST_TOOLSET_URL && install-tools /tmp/test_toolset.yml"
+  - docker run galaxy-docker/test bash -c "wget --output-document $GALAXY_HOME/test_toolset.yml $TEST_TOOLSET_URL && install-tools $GALAXY_HOME/test_toolset.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,7 @@ script:
   # Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
   # this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
   - sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH && cd $GALAXY_HOME/bioblend-0.7.0 && tox -e $TOX_ENV"
-  - docker run galaxy-docker/test bash -c "wget --output-document $GALAXY_HOME/test_toolset.yml $TEST_TOOLSET_URL && install-tools $GALAXY_HOME/test_toolset.yml"
+  # Test the 'old' tool installation script
+  - docker run galaxy-docker/test bash -c 'install-repository "--url https://toolshed.g2.bx.psu.edu -o iuc --name bedtools --panel-section-name 'BEDTools'"'
+  # Test the 'new' tool installation script
+  - docker run galaxy-docker/test bash -c "install-tools $GALAXY_HOME/ansible/galaxy-tools-playbook/files/tool_list.yaml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
   - GALAXY_USER_PASSWD=admin
   - BIOBLEND_GALAXY_API_KEY=admin
   - BIOBLEND_GALAXY_URL=http://localhost:8080
-  - TEST_TOOLSET_URL=https://raw.githubusercontent.com/afgane/docker-galaxy-stable/dev/galaxy/test_toolset.yml
 
   - git submodule update --init --recursive
   - sudo groupadd -r $GALAXY_TRAVIS_USER -g $GALAXY_GID

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - cd $GALAXY_HOME
   - sudo su $GALAXY_TRAVIS_USER -c 'wget https://github.com/galaxyproject/bioblend/archive/v0.7.0.tar.gz'
   - sudo su $GALAXY_TRAVIS_USER -c 'tar xfz v0.7.0.tar.gz'
-  - sudo su $GALAXY_TRAVIS_USER -c "wget --output-document ~/ansible/test_toolset.yml $TEST_TOOLSET_URL"
+  - sudo su $GALAXY_TRAVIS_USER -c "wget --output-document $GALAXY_HOME/test_toolset.yml $TEST_TOOLSET_URL"
 
 install:
   - cd $GALAXY_HOME/bioblend-0.7.0
@@ -50,4 +50,4 @@ script:
   # Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
   # this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
   - sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH && cd $GALAXY_HOME/bioblend-0.7.0 && tox -e $TOX_ENV"
-  - docker run galaxy-docker/test bash -c 'install-tools ~/ansible/test_toolset.yml'
+  - docker run galaxy-docker/test bash -c "install-tools $GALAXY_HOME/test_toolset.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_install:
   - cd $GALAXY_HOME
   - sudo su $GALAXY_TRAVIS_USER -c 'wget https://github.com/galaxyproject/bioblend/archive/v0.7.0.tar.gz'
   - sudo su $GALAXY_TRAVIS_USER -c 'tar xfz v0.7.0.tar.gz'
-  - sudo su $GALAXY_TRAVIS_USER -c "wget --output-document $GALAXY_HOME/test_toolset.yml $TEST_TOOLSET_URL"
 
 install:
   - cd $GALAXY_HOME/bioblend-0.7.0
@@ -54,4 +53,4 @@ script:
   # Run bioblend nosetests with the same UID and GID as the galaxy user inside if Docker
   # this will guarantee that exchanged files bewteen bioblend and Docker are read & writable from both sides
   - sudo -E su $GALAXY_TRAVIS_USER -c "export PATH=$GALAXY_HOME/.local/bin/:$PATH && cd $GALAXY_HOME/bioblend-0.7.0 && tox -e $TOX_ENV"
-  - docker run galaxy-docker/test bash -c "install-tools $GALAXY_HOME/test_toolset.yml"
+  - docker run galaxy-docker/test bash -c "wget --output-document /tmp/test_toolset.yml $TEST_TOOLSET_URL && install-tools /tmp/test_toolset.yml"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Galaxy Docker Image
 
 The [Galaxy](http://www.galaxyproject.org) [Docker](http://www.docker.io) Image is an easy distributable full-fledged Galaxy installation, that can be used for testing, teaching and presenting new tools and features.
 
-One of the main goals is to make the access to entire tool suites as easy as possible. Usually, 
-this includes the setup of a public available webservice that needs to be maintained, or that the Tool-user needs to either setup a Galaxy Server by its own or to have Admin access to a local Galaxy server. 
+One of the main goals is to make the access to entire tool suites as easy as possible. Usually,
+this includes the setup of a public available webservice that needs to be maintained, or that the Tool-user needs to either setup a Galaxy Server by its own or to have Admin access to a local Galaxy server.
 With docker, tool developers can create their own Image with all dependencies and the user only needs to run it within docker.
 
 The Image is based on [Ubuntu 14.04 LTS](http://releases.ubuntu.com/14.04/) and all recommended Galaxy requirements are installed. The following chart should illustrate the [Docker](http://www.docker.io) image hierarchy we have build to make is as easy as possible to build on different layers of our stack and create many exciting Galaxy flavours.
@@ -90,7 +90,7 @@ Note that there is no need to specifically bind individual ports (e.g., `-p 80:8
 Using Parent docker
 -------------------
 On some linux distributions, Docker-In-Docker can run into issues (such as running out of loopback interfaces). If this is an issue, you can use a 'legacy' mode that use a docker socket for the parent docker installation mounted inside the container. To engage, set the environmental variable `DOCKER_PARENT`
-  
+
   ```bash
   docker run -p 8080:80 -p 8021:21 -p 8800:8800 \
     --privileged=true -e DOCKER_PARENT=True \
@@ -134,7 +134,7 @@ You can and should overwrite these during launching your container:
 Note that if you would like to run any of the [cleanup scripts](https://wiki.galaxyproject.org/Admin/Config/Performance/Purge%20Histories%20and%20Datasets), you will need to add the following to `/export/galaxy-central/config/galaxy.ini`:
 
     database_connection = postgresql://galaxy:galaxy@localhost:5432/galaxy
-    file_path = /export/galaxy-central/database/files 
+    file_path = /export/galaxy-central/database/files
 
 Personalize your Galaxy
 -----------------------
@@ -227,16 +227,16 @@ Magic Environment variables
 Extending the Docker Image
 ==========================
 
-If your tools are already included in the Tool Shed, building your own personalised Galaxy docker Image (Galaxy flavour) can be done using the following steps:
+If the desired tools are already included in the Tool Shed, building your own personalised Galaxy docker Image (Galaxy flavour) can be done using the following steps:
 
- 1. Create a file the name ``Dockerfile``
+ 1. Create a file named ``Dockerfile``
  2. Include ``FROM bgruening/galaxy-stable`` at the top of the file. This means that you use the Galaxy Docker Image as base Image and build your own extensions on top of it.
- 3. Install your Tools from the Tool Shed via the ``install_tool_shed_repositories.py`` script.
- 4. execute ``docker build -t='my-docker-test'``
- 5. run your container with ``docker run -p 8080:80 my-docker-test``
- 6. open your web browser on ``http://localhost:8080``
+ 3. Supply the list of desired tools in a file (`my_tool_list.yml` below). See [this page](https://github.com/galaxyproject/ansible-galaxy-tools/blob/master/files/tool_list.yaml.sample) for the file format requirements.
+ 4. Execute ``docker build -t='my-docker-test'``
+ 5. Run your container with ``docker run -p 8080:80 my-docker-test``
+ 6. Open your web browser on ``http://localhost:8080``
 
-For example have a look at the [deepTools](http://deeptools.github.io/) or the [ChemicalToolBox](https://github.com/bgruening/galaxytools/tree/master/chemicaltoolbox) Dockerfile's.
+For a working example, have a look at the [deepTools](http://deeptools.github.io/) or the [ChemicalToolBox](https://github.com/bgruening/galaxytools/tree/master/chemicaltoolbox) Dockerfile's.
  * https://github.com/bgruening/docker-recipes/blob/master/galaxy-deeptools/Dockerfile
  * https://github.com/bgruening/docker-recipes/blob/master/galaxy-chemicaltoolbox/Dockerfile
 
@@ -259,8 +259,7 @@ RUN add-tool-shed --url 'http://testtoolshed.g2.bx.psu.edu/' --name 'Test Tool S
 RUN install-biojs msa
 
 # Install deepTools
-RUN install-repository \
-    "--url https://toolshed.g2.bx.psu.edu/ -o bgruening --name deeptools"
+RUN install-tools my_tool_list.yml
 
 # Mark folders as imported from the host.
 VOLUME ["/export/", "/data/", "/var/lib/docker"]
@@ -291,7 +290,7 @@ The Galaxy Admin User has the username ``admin@galaxy.org`` and the password ``a
 The PostgreSQL username is ``galaxy``, the password is ``galaxy`` and the database name is ``galaxy`` (I know I was really creative ;)).
 If you want to create new users, please make sure to use the ``/export/`` volume. Otherwise your user will be removed after your docker session is finished.
 
-The proftpd server is configured to use the main galaxy PostgreSQL user to access the database and select the username and password. If you want to run the 
+The proftpd server is configured to use the main galaxy PostgreSQL user to access the database and select the username and password. If you want to run the
 docker container in production, please do not forget to change the user credentials in /etc/proftp/proftpd.conf too.
 
 The Galaxy Report Webapp is `htpasswd` protected with username and password st to `admin`.

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -166,6 +166,7 @@ RUN service postgresql start && \
 
 # Add Ansible playbook for installing tools
 ADD roles/galaxy-tools-playbook $GALAXY_HOME/ansible/galaxy-tools-playbook
+RUN chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_HOME/ansible
 
 # Activate additional Tool Sheds
 # Activate the Test Tool Shed during runtime, useful for testing repositories.

--- a/galaxy/test_toolset.yml
+++ b/galaxy/test_toolset.yml
@@ -1,0 +1,6 @@
+tools:
+- name: bedtools
+  owner: iuc
+  tool_panel_section_id: textutil
+  revisions:
+  - 2cd7e321d259

--- a/galaxy/test_toolset.yml
+++ b/galaxy/test_toolset.yml
@@ -1,6 +1,0 @@
-tools:
-- name: bedtools
-  owner: iuc
-  tool_panel_section_id: textutil
-  revisions:
-  - 2cd7e321d259


### PR DESCRIPTION
I switched the tool installation testing to the Ansible playbook/command built into the container. This way it's testing it as well plus it is used as an example for how to use the playbook. I specified the revision for the tools so we're certain they install and it's not the tool that's busted. 