### PR TITLE
Condor support

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get install --no-install-recommends -y mercurial python-psycopg2 postgresql-9.3 sudo samtools python-virtualenv wget \
     nginx-extras nginx-common uwsgi uwsgi-plugin-python supervisor lxc-docker-1.9.1 slurm-llnl slurm-llnl-torque libswitch-perl \
     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev nodejs-legacy npm ansible \
-    nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 && \
+    nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 htcondor && \
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -184,6 +184,10 @@ ADD install_tools_wrapper.sh /usr/bin/install-tools
 ADD install_biojs_vis.sh /usr/bin/install-biojs
 RUN chmod +x /usr/bin/install-tools /usr/bin/startup /usr/bin/startup_lite /usr/bin/install-biojs /usr/bin/add-tool-shed
 
+#Add condor-specific files
+ADD startCondor.sh /usr/bin/startCondor.sh
+RUN chmod +x /usr/bin/startCondor.sh /usr/bin/startCondor.sh
+
 # This needs to happen here and not above, otherwise the Galaxy start
 # (without running the startup.sh script) will crash because integrated_tool_panel.xml could not be found.
 ENV GALAXY_CONFIG_INTEGRATED_TOOL_PANEL_CONFIG /export/galaxy-central/integrated_tool_panel.xml
@@ -199,4 +203,4 @@ EXPOSE :9002
 VOLUME ["/export/", "/data/", "/var/lib/docker"]
 
 # Autostart script that is invoked during container start
-CMD ["/usr/bin/startup"]
+CMD ["/usr/bin/startCondor.sh"]

--- a/galaxy/startCondor.sh
+++ b/galaxy/startCondor.sh
@@ -11,4 +11,4 @@ then
     fi
     /etc/init.d/condor start
 fi
-bash /usr/bin/startup
+source /usr/bin/startup

--- a/galaxy/startCondor.sh
+++ b/galaxy/startCondor.sh
@@ -11,4 +11,5 @@ then
         /etc/init.d/condor start
     fi
 fi
+
 bash /usr/bin/startup

--- a/galaxy/startCondor.sh
+++ b/galaxy/startCondor.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ "x$ENABLE_CONDOR" != "x" ]
+then
+    echo "Enabling Condor"
+    if [ -e /export/condor_config ]
+    then
+        rm -f /etc/condor/condor_config
+        ln -s /export/condor_config /etc/condor/condor_config
+        /etc/init.d/condor start
+    fi
+fi
+bash /usr/bin/startup

--- a/galaxy/startCondor.sh
+++ b/galaxy/startCondor.sh
@@ -8,8 +8,7 @@ then
     then
         rm -f /etc/condor/condor_config
         ln -s /export/condor_config /etc/condor/condor_config
-        /etc/init.d/condor start
     fi
+    /etc/init.d/condor start
 fi
-
 bash /usr/bin/startup


### PR DESCRIPTION
@abdulrahmanazab This should work as a starting point. If you use `docker run -e "ENABLE_CONDOR=true" ...` then the condor stuff should get started. If `/export/condor_config` exists then it should be symlinked into `/etc/condor` and used.

This is pretty hacky, given that it'd be preferable to use the same methods as with slurm, but it's a first pass.