### PR TITLE
Take Galaxy virtualenv out of GALAXY_ROOT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,34 @@ The following is an example for how to specify a destination in `job_conf.xml` t
 
 The usage of `-n` can be confusing. Note that it will specify the number of cores, not the number of tasks (i.e., it's not equivalent to `srun -n 4`).
 
+Tips for Running Jobs Outside the Container
+---------------------------------------------
+
+In its default state Galaxy is assumes both the Galaxy source code and
+various temporary files are available on shared file systems across the
+cluster. When using Condor or SLURM (as described above) to run jobs outside
+of the Docker container one can take steps to mitegate these assumptions.
+
+The ``embed_metadata_in_job`` option on job destinations in `job_conf.xml`
+forces Galaxy collect metadata inside the container instead of on the
+cluster:
+
+    <param id="embed_metadata_in_job">False</param>
+
+This has performance implications and may not scale as well as performing
+these calculations on the remote cluster - but this should not be a problem
+for most Galaxy instances.
+
+Additionally, many framework tools depend on Galaxy's Python virtual
+environment being avaiable. This should be created outside of the container
+on a shared filesystem available to your cluster using the instructions
+[here](https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/framework_dependencies.rst#managing-dependencies-manually). Job destinations
+can then source these virtual environments using the instructions outlined
+[here](https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/framework_dependencies.rst#galaxy-job-handlers). In other words, by adding
+a line such as this to each job destination:
+
+    <env file="/path/to/shared/galaxy/venv" />
+
 Magic Environment variables
 ===========================
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -19,7 +19,7 @@ GALAXY_CONFIG_DIR=/etc/galaxy
 ENV GALAXY_CONFIG_FILE=$GALAXY_CONFIG_DIR/galaxy.ini \
 GALAXY_CONFIG_JOB_CONFIG_FILE=$GALAXY_CONFIG_DIR/job_conf.xml \
 GALAXY_CONFIG_JOB_METRICS_CONFIG_FILE=$GALAXY_CONFIG_DIR/job_metrics_conf.xml \
-GALAXY_VIRTUALENV=$GALAXY_ROOT/.venv/ \
+GALAXY_VIRTUAL_ENV=/galaxy_venv \
 GALAXY_USER=galaxy \
 GALAXY_UID=1450 \
 GALAXY_GID=1450 \
@@ -55,7 +55,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get install --no-install-recommends -y mercurial python-psycopg2 postgresql-9.3 sudo samtools python-virtualenv wget \
     nginx-extras nginx-common uwsgi uwsgi-plugin-python supervisor lxc-docker-1.9.1 slurm-llnl slurm-llnl-torque libswitch-perl \
     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev nodejs-legacy npm ansible \
-    nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 htcondor python-ldap && \
+    nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 python-psutil htcondor python-ldap && \
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -69,6 +69,8 @@ ADD ./bashrc $GALAXY_HOME/.bashrc
 # Download latest stable release of Galaxy.
 RUN mkdir $GALAXY_ROOT && \
     wget -q -O - $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT && \
+    virtualenv $GALAXY_VIRTUAL_ENV && \
+    chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_VIRTUAL_ENV && \
     chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_ROOT && \
     # Setup Galaxy configuration files.
     mkdir -p $GALAXY_CONFIG_DIR $GALAXY_CONFIG_DIR/web && \
@@ -81,13 +83,14 @@ ADD ./htpasswd /etc/nginx/htpasswd
 ADD roles/ /tmp/ansible/roles
 ADD provision.yml /tmp/ansible/provision.yml
 RUN ansible-playbook /tmp/ansible/provision.yml \
+    --extra-vars galaxy_venv_dir=$GALAXY_VIRTUAL_ENV \
     --extra-vars galaxy_user_name=$GALAXY_USER \
     --extra-vars galaxy_config_file=$GALAXY_CONFIG_FILE \
     --extra-vars galaxy_config_dir=$GALAXY_CONFIG_DIR \
     --extra-vars galaxy_job_conf_path=$GALAXY_CONFIG_JOB_CONFIG_FILE \
     --extra-vars galaxy_job_metrics_conf_path=$GALAXY_CONFIG_JOB_METRICS_CONFIG_FILE \
     --extra-vars supervisor_manage_slurm="" \
-    --extra-vars galaxy_venv_dir=$GALAXY_VIRTUALENV \
+    --extra-vars galaxy_venv_dir=$GALAXY_VIRTUAL_ENV \
     --tags=galaxyextras -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -161,9 +164,8 @@ ADD ./export_user_files.py /usr/local/bin/export_user_files.py
 RUN rm $PG_DATA_DIR_DEFAULT -rf && \
     python /usr/local/bin/setup_postgresql.py --dbuser galaxy --dbpassword galaxy --db-name galaxy --dbpath $PG_DATA_DIR_DEFAULT && \
     service postgresql start && \
+    . $GALAXY_VIRTUAL_ENV/bin/activate && \
     sh create_db.sh -c $GALAXY_CONFIG_FILE && \
-    . $GALAXY_ROOT/.venv/bin/activate && \
-    pip install psutil && \
     python /usr/local/bin/create_galaxy_user.py --user $GALAXY_DEFAULT_ADMIN_USER --password $GALAXY_DEFAULT_ADMIN_PASSWORD -c $GALAXY_CONFIG_FILE --key $GALAXY_DEFAULT_ADMIN_KEY && \
     service postgresql stop
 

--- a/galaxy/install_tools_wrapper.sh
+++ b/galaxy/install_tools_wrapper.sh
@@ -43,7 +43,7 @@ done
 su galaxy -c "cd $GALAXY_HOME/ansible/galaxy-tools-playbook; unset PYTHONPATH; \
     ansible-playbook tools.yml -i "localhost," --extra-vars galaxy_tools_api_key=admin \
     --extra-vars galaxy_config_file=/etc/galaxy/galaxy.ini \
-    --extra-vars galaxy_venv_dir=$GALAXY_HOME/venv \
+    --extra-vars galaxy_venv_dir=$GALAXY_VIRTUAL_ENV \
     --extra-vars galaxy_server_dir=/galaxy-central \
     --extra-vars galaxy_tools_tool_list=$1"
 


### PR DESCRIPTION
This is an important step toward making it possible to mount an external Galaxy source root ($GALAXY_ROOT).

Requires an update to ansible-galaxy-extras which slightly tweaked the way configure_slurm.py is called so the psutil install is handled a little diffently.

xref #144.