### PR TITLE
Install docker in slurm container ...

### DIFF
--- a/test/slurm/Dockerfile
+++ b/test/slurm/Dockerfile
@@ -4,7 +4,12 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
     slurm-llnl slurm-llnl-torque slurm-drmaa-dev \
-    python-pip python-psutil supervisor samtools
+    python-pip python-psutil supervisor samtools apt-transport-https software-properties-common
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
+    --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list" && \
+    apt-get update && \
+    apt-get install -y docker-engine
 RUN adduser galaxy &&\
     /usr/sbin/create-munge-key &&\
     touch /var/log/slurm-llnl/slurmctld.log /var/log/slurm-llnl/slurmd.log &&\
@@ -25,7 +30,9 @@ ENV GALAXY_DIR=/export/galaxy-central \
     SLURM_PARTITION_NAME=work \
     SLURM_CLUSTER_NAME=Cluster \
     SLURMD_AUTOSTART=True \
-    SLURMCTLD_AUTOSTART=True
+    SLURMCTLD_AUTOSTART=True \
+    SLURM_CONF_PATH=/export/slurm.conf \
+    MUNGE_KEY_PATH=/export/munge.key
 
-VOLUME ["/export/"]
+VOLUME ["/export/", "/var/lib/docker"]
 CMD ["/usr/bin/startup.sh"]

--- a/test/slurm/startup.sh
+++ b/test/slurm/startup.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 
 # Setup the galaxy user UID/GID and pass control on to supervisor
+if id "$SLURM_USER_NAME" >/dev/null 2>&1; then
+        echo "user exists"
+else
+        echo "user does not exist, creating"
+        useradd -m -d /var/"$SLURM_USER_NAME" "$SLURM_USER_NAME"
+fi
 usermod -u $SLURM_UID  $SLURM_USER_NAME
 groupmod -g $SLURM_GID $SLURM_USER_NAME
-if [ -f /export/munge.key ]
-  then cp /export/munge.key /etc/munge/munge.key
-else
-  cp /etc/munge/munge.key /export/munge.key
+if [ ! -f "$MUNGE_KEY_PATH" ]
+  then
+    cp /etc/munge/munge.key "$MUNGE_KEY_PATH"
 fi
 
-if [ -f /export/slurm.conf ]
-  then cp /export/slurm.conf /etc/slurm-llnl/slurm.conf
-else
-  python /usr/local/bin/configure_slurm.py
-  cp /etc/slurm-llnl/slurm.conf /export/slurm.conf
+if [ ! -f "$SLURM_CONF_PATH" ]
+  then
+    python /usr/local/bin/configure_slurm.py
+    cp /etc/slurm-llnl/slurm.conf "$SLURM_CONF_PATH"
 fi
 if [ ! -f "$GALAXY_DIR"/.venv ]
   then
@@ -26,5 +30,5 @@ if [ ! -f "$GALAXY_DIR"/.venv ]
 fi
 chown $SLURM_USER_NAME /tmp/slurm
 ln -s "$GALAXY_DIR" "$SYMLINK_TARGET"
+ln -s "$SLURM_CONF_PATH" /etc/slurm-llnl/slurm.conf
 exec /usr/local/bin/supervisord -n -c /etc/supervisor/supervisord.conf
-

--- a/test/slurm/supervisor_slurm.conf
+++ b/test/slurm/supervisor_slurm.conf
@@ -1,17 +1,17 @@
 [program:munge]
 user=root
-command=/usr/sbin/munged -F --force
+command=/usr/sbin/munged --key-file=%(ENV_MUNGE_KEY_PATH)s -F --force
 
 [program:slurmctld]
 user=root
-command=/usr/sbin/slurmctld -D -L /var/log/slurm-llnl/slurmctld.log
+command=/usr/sbin/slurmctld -D -L /var/log/slurm-llnl/slurmctld.log -f %(ENV_SLURM_CONF_PATH)s
 autostart       = %(ENV_SLURMCTLD_AUTOSTART)s
 autorestart     = true
 priority        = 200
 
 [program:slurmd]
 user=root
-command=/usr/sbin/slurmd -D -L /var/log/slurm-llnl/slurmd.log
+command=/usr/sbin/slurmd -f %(ENV_SLURM_CONF_PATH)s -D -L /var/log/slurm-llnl/slurmd.log
 autostart       = %(ENV_SLURMD_AUTOSTART)s
 autorestart     = true
 priority        = 300

--- a/test/slurm/test.sh
+++ b/test/slurm/test.sh
@@ -2,9 +2,9 @@
 
 # Test that jobs run successfully on an external slurm cluster
 
-# We use /tmp as an export dir that will hold the shared data between
+# We use a temporary directory as an export dir that will hold the shared data between
 # galaxy and slurm:
-EXPORT=/tmp
+EXPORT=`mktemp --directory`
 # We build the slurm image
 docker build -t slurm .
 # We fire up a slurm node (with hostname slurm)
@@ -28,8 +28,6 @@ docker run -d -e "NONUSE=slurmd,slurmctld" \
    -p 80:80 -v "$EXPORT":/export quay.io/bgruening/galaxy
 # Let's submit a job from the galaxy container and check it runs in the slurm container
 sleep 40s
-docker cp testscript.sh galaxy-slurm-test:/export/galaxy-central/testscript.sh
-docker exec galaxy-slurm-test chmod +x /export/galaxy-central/testscript.sh
 docker exec galaxy-slurm-test su - galaxy -c 'srun hostname' | grep slurm && \
 docker stop galaxy-slurm-test slurm && \
 docker rm galaxy-slurm-test slurm


### PR DESCRIPTION
and mark /var/lib/docker as volume for docker-in-docker use.
Also instruct slurm to load slurm.conf and munge.key directly
from /export directory (the file location can be controlled with
`-e SLURM_CONF_PATH=path/to/slurm.conf` and `MUNGE_KEY_PATH=path/to/munge.key`).