### PR TITLE
Add GridEngine client and it's DRMAA

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -59,8 +59,8 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     apt-get install --no-install-recommends -y mercurial python-psycopg2 postgresql-9.3 sudo samtools python-virtualenv \
     nginx-extras=1.4.6-1ubuntu3.4ppa1 nginx-common=1.4.6-1ubuntu3.4ppa1 uwsgi uwsgi-plugin-python supervisor lxc-docker-1.9.1 slurm-llnl slurm-llnl-torque libswitch-perl \
     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev nodejs-legacy npm ansible \
-    nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 python-psutil condor python-ldap && \
-    apt-get install --no-install-recommends -y gridengine-client gridengine-drmaa1.0 && \
+    nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 python-psutil condor python-ldap \
+    gridengine-common gridengine-drmaa1.0 && \
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get -qq update && apt-get install --no-install-recommends -y apt-transpo
     nginx-extras=1.4.6-1ubuntu3.4ppa1 nginx-common=1.4.6-1ubuntu3.4ppa1 uwsgi uwsgi-plugin-python supervisor lxc-docker-1.9.1 slurm-llnl slurm-llnl-torque libswitch-perl \
     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev nodejs-legacy npm ansible \
     nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 python-psutil condor python-ldap && \
+    apt-get install --no-install-recommends -y gridengine-client gridengine-drmaa1.0 && \
     pip install --upgrade pip && \
     apt-get purge -y software-properties-common && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Add GridEngine client and it's DRMAA

I tested it with Sun GridEngine and OpenGridScheduler (not current docker dev image but I think it will work)

first I wrote

> nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 python-psutil condor python-ldap && \
gridengine-client gridengine-drmaa1.0 && \

but it caused error 

> Processing triggers for libc-bin (2.19-0ubuntu6.9) ...
/bin/sh: 1: gridengine-client: not found
The command '/bin/sh -c apt-get -qq update && apt-get install --no-install-recommends -y apt-transport-https software-properties-common wget &&     apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D &&     sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list" &&     sh -c "echo deb http://research.cs.wisc.edu/htcondor/ubuntu/stable/ trusty contrib > /etc/apt/sources.list.d/htcondor.list" &&     sh -c "wget -qO - http://research.cs.wisc.edu/htcondor/ubuntu/HTCondor-Release.gpg.key | sudo apt-key add -" &&     apt-add-repository -y ppa:ansible/ansible &&     apt-add-repository -y ppa:galaxyproject/nginx &&     apt-get update -qq && apt-get upgrade -y &&     apt-get install --no-install-recommends -y mercurial python-psycopg2 postgresql-9.3 sudo samtools python-virtualenv     nginx-extras=1.4.6-1ubuntu3.4ppa1 nginx-common=1.4.6-1ubuntu3.4ppa1 uwsgi uwsgi-plugin-python supervisor lxc-docker-1.9.1 slurm-llnl slurm-llnl-torque libswitch-perl     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev nodejs-legacy npm ansible     nano nmap lynx vim curl python-pip python-gnuplot python-rpy2 python-psutil condor python-ldap &&     gridengine-client gridengine-drmaa1.0 &&     pip install --upgrade pip &&     apt-get purge -y software-properties-common &&     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*' returned a non-zero code: 127
`

so I change to current pull request style