### PR TITLE
Not create conf.d/25ansible_postgresql.conf

### DIFF
--- a/galaxy/postgresql_provision.yml
+++ b/galaxy/postgresql_provision.yml
@@ -10,5 +10,6 @@
       ident_file: "'/etc/postgresql/9.3/main/pg_ident.conf'"
     postgresql_pg_hba_conf:
       - host all all 0.0.0.0/0 md5
+    postgresql_option_config: false
   roles:
       - role: galaxy-postgresql


### PR DESCRIPTION
This PR is that it is not create ```conf.d/25ansible_postgresql.conf``` .
And this requires [https://github.com/galaxyproject/ansible-postgresql/pull/9](https://github.com/galaxyproject/ansible-postgresql/pull/9)