### PR TITLE
Get 16.07 branch, install 4.05 conda before downgrading

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -162,9 +162,9 @@ RUN ./scripts/common_startup.sh && \
     cd $GALAXY_ROOT/lib/galaxy/web/proxy/js && \
     npm install && \
     wget https://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh && \
-    bash Miniconda2-4.0.5-Linux-x86_64.sh -b -p $GALAXY_CONDA_PREFIX && \
-    rm Miniconda2-4.0.5-latest-Linux-x86_64.sh && \
-    $GALAXY_CONDA_PREFIX/bin/conda install conda==3.19.3
+    bash Miniconda3-4.0.5-Linux-x86_64.sh -b -p $GALAXY_CONDA_PREFIX && \
+    rm Miniconda3-4.0.5-latest-Linux-x86_64.sh && \
+    $GALAXY_CONDA_PREFIX/bin/conda install -y conda==3.19.3
 
 # Container Style
 ADD GalaxyDocker.png $GALAXY_CONFIG_DIR/web/welcome_image.png

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -11,7 +11,7 @@ MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 # * Enable the @natefoo magic
 # Web server infrastructure matching usegalaxy.org - supervisor, uwsgi, and nginx.
 
-ENV GALAXY_RELEASE=dev \
+ENV GALAXY_RELEASE=release_16.07 \
 GALAXY_REPO=https://github.com/galaxyproject/galaxy \
 GALAXY_ROOT=/galaxy-central \
 GALAXY_CONFIG_DIR=/etc/galaxy
@@ -161,9 +161,9 @@ RUN ./scripts/common_startup.sh && \
     # Install all required Node dependencies. This is required to get proxy support to work for Interactive Environments
     cd $GALAXY_ROOT/lib/galaxy/web/proxy/js && \
     npm install && \
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p $GALAXY_CONDA_PREFIX && \
-    rm Miniconda3-latest-Linux-x86_64.sh && \
+    wget https://repo.continuum.io/miniconda/Miniconda3-4.0.5-Linux-x86_64.sh && \
+    bash Miniconda2-4.0.5-Linux-x86_64.sh -b -p $GALAXY_CONDA_PREFIX && \
+    rm Miniconda2-4.0.5-latest-Linux-x86_64.sh && \
     $GALAXY_CONDA_PREFIX/bin/conda install conda==3.19.3
 
 # Container Style


### PR DESCRIPTION
Ping @bgruening 

I don't think I can easily update the ansible-galaxy-tools role though,
we first have to upgrade enis' ansible-galaxy-tools playbook, since the role comes as a dependency. But I think this change here is important and needs to get out ASAP.