### PR TITLE
HTTPS support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "galaxy/roles/galaxyproject.galaxyextras"]
 	path = galaxy/roles/galaxyprojectdotorg.galaxyextras
-	url = https://github.com/zfrenchee/ansible-galaxy-extras
+	url = https://github.com/galaxyproject/ansible-galaxy-extras
 [submodule "galaxy/roles/galaxy-postgresql"]
 	path = galaxy/roles/galaxy-postgresql
 	url = https://github.com/galaxyproject/ansible-postgresql

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "galaxy/roles/galaxyproject.galaxyextras"]
 	path = galaxy/roles/galaxyprojectdotorg.galaxyextras
-	url = https://github.com/galaxyproject/ansible-galaxy-extras
+	url = https://github.com/zfrenchee/ansible-galaxy-extras
 [submodule "galaxy/roles/galaxy-postgresql"]
 	path = galaxy/roles/galaxy-postgresql
 	url = https://github.com/galaxyproject/ansible-postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ script:
 
   # Test SFTP Server
   - sshpass -p $GALAXY_USER_PASSWD sftp -v -P 8022 -o User=$GALAXY_USER -o "StrictHostKeyChecking no" localhost <<< $'put time.txt'
+  # Test self-signed HTTPS
+  - docker run -d -p 443:443 -e "USE_HTTPS=True" quay.io/bgruening/galaxy
+  - sleep 60s && curl -k --fail https://127.0.0.1:443/api/version
+  - echo | openssl s_client -connect 127.0.0.1:443 2>/dev/null | openssl x509 -issuer -noout| grep selfsigned
 
   - cd $TRAVIS_BUILD_DIR/test/bioblend/ && bash test.sh && cd $TRAVIS_BUILD_DIR/
   # Test the 'old' tool installation script

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -40,6 +40,11 @@ EXPORT_DIR=/export \
 # The following 2 ENV vars can be used to set the number of uwsgi processes and threads
 UWSGI_PROCESSES=2 \
 UWSGI_THREADS=4 \
+# Set HTTPS to use a self-signed certificate (or your own certificate in /export/{server.key,server.crt})
+USE_HTTPS=False \
+# Set USE_HTTPS_LENSENCRYPT and GALAXY_DOMAIN to a domain that is reachable to get a letsencrypt certificate
+USE_HTTPS_LETSENCRYPT=False \
+GALAXY_DOMAIN=localhost \
 # Set the number of Galaxy handlers
 GALAXY_HANDLER_NUMPROCS=2 \
 # Setting a standard encoding. This can get important for things like the unix sort tool.
@@ -210,9 +215,10 @@ RUN echo "DISCARD_SESSION_KEYRING_ON_STARTUP=False" > /etc/condor/condor_config.
 # (without running the startup.sh script) will crash because integrated_tool_panel.xml could not be found.
 ENV GALAXY_CONFIG_INTEGRATED_TOOL_PANEL_CONFIG /export/galaxy-central/integrated_tool_panel.xml
 
-# Expose port 80 (webserver), 21 (FTP server), 8800 (Proxy), 9002 (supvisord web app)
-EXPOSE :80
+# Expose port 80, 443 (webserver), 21 (FTP server), 8800 (Proxy), 9002 (supvisord web app)
 EXPOSE :21
+EXPOSE :80
+EXPOSE :443
 EXPOSE :8800
 EXPOSE :9002
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -42,9 +42,9 @@ UWSGI_PROCESSES=2 \
 UWSGI_THREADS=4 \
 # Set HTTPS to use a self-signed certificate (or your own certificate in /export/{server.key,server.crt})
 USE_HTTPS=False \
-# Set USE_HTTPS_LENSENCRYPT and GALAXY_DOMAIN to a domain that is reachable to get a letsencrypt certificate
+# Set USE_HTTPS_LENSENCRYPT and GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL to a domain that is reachable to get a letsencrypt certificate
 USE_HTTPS_LETSENCRYPT=False \
-GALAXY_DOMAIN=localhost \
+GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=localhost \
 # Set the number of Galaxy handlers
 GALAXY_HANDLER_NUMPROCS=2 \
 # Setting a standard encoding. This can get important for things like the unix sort tool.

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -97,11 +97,11 @@ RUN su $GALAXY_USER -c "cp $GALAXY_ROOT/config/galaxy.ini.sample $GALAXY_CONFIG_
 ADD ./reports_wsgi.ini.sample $GALAXY_CONFIG_DIR/reports_wsgi.ini
 
 ADD sample_tool_list.yaml $GALAXY_HOME/ephemeris/sample_tool_list.yaml
-ADD roles/ /tmp/ansible/roles
-ADD provision.yml /tmp/ansible/provision.yml
-ADD postgresql_provision.yml /tmp/ansible/postgresql_provision.yml
-RUN ansible-playbook /tmp/ansible/postgresql_provision.yml && \
-    ansible-playbook /tmp/ansible/provision.yml \
+ADD roles/ /ansible/roles
+ADD provision.yml /ansible/provision.yml
+ADD postgresql_provision.yml /ansible/postgresql_provision.yml
+RUN ansible-playbook /ansible/postgresql_provision.yml && \
+    ansible-playbook /ansible/provision.yml \
     --extra-vars galaxy_venv_dir=$GALAXY_VIRTUAL_ENV \
     --extra-vars galaxy_log_dir=$GALAXY_LOGS_DIR \
     --extra-vars galaxy_user_name=$GALAXY_USER \


### PR DESCRIPTION
To use a self-signed certificate and HTTPS, start with `-e USE_HTTPS=True`.
If you have your own certificates, copy them to /export/{server.key,server.crt}.
If you want to use letsencrypt, start with `-e USE_HTTPS_LETSENCRYPT=True -e GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL =<your_domain>`.

If you use HTTPS, you also need to make sure port 443 is available.
@zfrenchee can you add the more extended documentation you had in https://github.com/galaxyproject/ansible-galaxy-extras/pull/103 ?