### PR TITLE
PROXY_PREFIX doc + enable nginx_use_remote_header

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The Image is based on [Ubuntu 14.04 LTS](http://releases.ubuntu.com/14.04/) and 
   - [Using Parent docker](#Using-Parent-docker)
   - [Galaxy Report Webapp](#Galaxy-Report-Webapp)
   - [Galaxy's config settings](#Galaxys-config-settings)
+  - [Configuring Galaxy's behind a proxy](#Galaxy-behind-proxy)
   - [Personalize your Galaxy](#Personalize-your-Galaxy)
   - [Deactivating services](#Deactivating-services)
   - [Restarting Galaxy](#Restarting-Galaxy)
@@ -224,6 +225,22 @@ Note that if you would like to run any of the [cleanup scripts](https://wiki.gal
 ```
 database_connection = postgresql://galaxy:galaxy@localhost:5432/galaxy
 file_path = /export/galaxy-central/database/files
+```
+
+## Configuring Galaxy's behind a proxy <a name="Galaxy-behind-proxy" /> [[toc]](#toc)
+
+If your Galaxy docker instance is running behind an HTTP proxy server, and if you're accessing it with a specific path prefix (e.g. http://www.example.org/some/prefix/), you need to make Galaxy aware of it. There is an environment variable available to do so:
+
+```
+PROXY_PREFIX=/some/prefix
+```
+
+You can and should overwrite these during launching your container:
+
+```sh
+docker run -p 8080:80 \
+    -e "PROXY_PREFIX=/some/prefix" \
+    bgruening/galaxy-stable
 ```
 
 ## Personalize your Galaxy <a name="Personalize-your-Galaxy" /> [[toc]](#toc)

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -127,6 +127,7 @@ RUN ansible-playbook /ansible/postgresql_provision.yml && \
     --extra-vars nginx_upload_store_path=/export/nginx_upload_store \
     --extra-vars supervisor_postgres_config_path=$PG_CONF_DIR_DEFAULT/postgresql.conf \
     --extra-vars supervisor_postgres_autostart=false \
+    --extra-vars nginx_use_remote_header=True \
     --tags=galaxyextras -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Added some doc (and default value) for the new PROXY_PREFIX var.
Also enabled the nginx_use_remote_header setting to allow external auth from an http proxy