### PR TITLE
Allow for multiple condor executors and scaling

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -102,8 +102,8 @@ services:
     privileged: True # HTCondor wants a RW cgroups mount. A RO cgroups mount throws an error in ProcD for running jobs.
     environment:
         - CONDOR_HOST=galaxy-htcondor
-        - CONDOR_CPUS=6
-        - CONDOR_MEMORY=6144
+        - CONDOR_CPUS=2
+        - CONDOR_MEMORY=2048
     volumes:
         - ./galaxy-storage/:/export/
         - /var/run/docker.sock:/var/run/docker.sock

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -90,18 +90,23 @@ services:
 
   galaxy-htcondor-executor:
     image: quay.io/bgruening/galaxy-htcondor-executor:compose
-    container_name: galaxy-htcondor-executor
-    hostname: galaxy-htcondor-executor
     privileged: True # HTCondor wants a RW cgroups mount. A RO cgroups mount throws an error in ProcD for running jobs.
     environment:
         - CONDOR_HOST=galaxy-htcondor
     volumes:
         - ./galaxy-storage/:/export/
         - /var/run/docker.sock:/var/run/docker.sock
-    #links:
-    #    - galaxy-web
-    #    - galaxy-htcondor
 
+  galaxy-htcondor-executor-big:
+    image: quay.io/bgruening/galaxy-htcondor-executor:compose
+    privileged: True # HTCondor wants a RW cgroups mount. A RO cgroups mount throws an error in ProcD for running jobs.
+    environment:
+        - CONDOR_HOST=galaxy-htcondor
+        - CONDOR_CPUS=6
+        - CONDOR_MEMORY=6144
+    volumes:
+        - ./galaxy-storage/:/export/
+        - /var/run/docker.sock:/var/run/docker.sock
 
   # Messagequeue for better performance
   rabbitmq:

--- a/compose/galaxy-htcondor-executor/Dockerfile
+++ b/compose/galaxy-htcondor-executor/Dockerfile
@@ -30,6 +30,9 @@ RUN groupadd -r $GALAXY_USER -g $GALAXY_GID && \
     chmod 750 /root/.docker && \
     chmod +rx /root
 
+ENV CONDOR_CPUS=1 \
+    CONDOR_MEMORY=1024
+
 ADD startup.sh /usr/bin/startup.sh
 RUN chmod +x /usr/bin/startup.sh
 CMD ["/usr/bin/startup.sh"]

--- a/compose/galaxy-htcondor-executor/startup.sh
+++ b/compose/galaxy-htcondor-executor/startup.sh
@@ -6,6 +6,10 @@ DAEMON_LIST = MASTER, STARTD
 DISCARD_SESSION_KEYRING_ON_STARTUP=False
 TRUST_UID_DOMAIN=true
 
+NUM_SLOTS=1
+NUM_SLOTS_TYPE_1=1
+SLOT_TYPE_1=Cpu=${CONDOR_CPUS},mem=${CONDOR_MEMORY}
+
 # Disable cgroup support by defining the base cgroup as an empty string
 BASE_CGROUP=
 


### PR DESCRIPTION
This PR adds the necessary configuration for multiple, individually sized and scaled HTCondor runners. Two are defined in the docker-compose.yml, and one of each will be run by default.

Simply pass two environment variables to control how many cores and how much RAM each executor gets:

```
CONDOR_CPUS=4
CONDOR_MEMORY=4096
```

Here we've defined an executor with 4 cores and 4 Gigs of ram. We can add as many different "flavours" of executors as needed to split up the machine however is desired. If you want many slots of a particular size, once you've launched the compose stack, simply rescale the executors!

```
docker-compose scale galaxy-htcondor-executor=5
```

magic, now you have 5 slots of the smaller executor. This should be really nice for spreading executors across a k8s/mesos cluster?