### PR TITLE
Update buildlocal.sh to use the master branch of ansible galaxy extras.

### DIFF
--- a/compose/buildlocal.sh
+++ b/compose/buildlocal.sh
@@ -2,7 +2,7 @@
 set -x -e
 
 ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
-ANSIBLE_RELEASE=1e07cc8a56cd18821a9f20129c400a242d25d1a0
+ANSIBLE_RELEASE=master
 
 GALAXY_RELEASE=dev
 GALAXY_REPO=galaxyproject/galaxy


### PR DESCRIPTION
The k8s stuff is breaking unrelated parts of docker-galaxy-stable and I'm trying to isolate the change that is causing this. If the tests pass I can replace this with a specific commit hash if you'd prefer.