### PR TITLE
Add required perl lib for qstat command

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -77,7 +77,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     nginx-extras=1.4.6-1ubuntu3.4ppa1 nginx-common=1.4.6-1ubuntu3.4ppa1 supervisor docker-ce slurm-llnl slurm-llnl-torque \
     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev nodejs-legacy npm ansible \
     nano vim curl python-crypto python-pip python-psutil condor python-ldap \
-    gridengine-common gridengine-drmaa1.0 rabbitmq-server && \
+    gridengine-common gridengine-drmaa1.0 rabbitmq-server libswitch-perl && \
     pip install --upgrade pip && \
     pip install ephemeris && \
     apt-get purge -y software-properties-common && \


### PR DESCRIPTION
Qstat fails when this package is not installed:
```
Can't locate Switch.pm in @INC (you may need to install the Switch module) (@INC contains: /usr/lib/perl/5.18.2 /etc/perl /usr/local/lib/perl/5.18.2 /usr/local/share/perl/5.18.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.18 /usr/share/perl/5.18 /usr/local/lib/site_perl .) at /usr/bin/qstat line 53, <DATA> line 604.
BEGIN failed--compilation aborted at /usr/bin/qstat line 53, <DATA> line 604.
```
I don't know if you'd prefer this to go to the dev branch instead?