### PR TITLE
Add scheme to infrastructure url

### DIFF
--- a/compose/galaxy-web/Dockerfile
+++ b/compose/galaxy-web/Dockerfile
@@ -14,7 +14,7 @@ UWSGI_THREADS=4 \
 USE_HTTPS=False \
 # Set USE_HTTPS_LENSENCRYPT and GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL to a domain that is reachable to get a letsencrypt certificate
 USE_HTTPS_LETSENCRYPT=False \
-GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=localhost \
+GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://localhost \
 # Set the number of Galaxy handlers
 GALAXY_HANDLER_NUMPROCS=2
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -48,7 +48,7 @@ UWSGI_THREADS=4 \
 USE_HTTPS=False \
 # Set USE_HTTPS_LENSENCRYPT and GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL to a domain that is reachable to get a letsencrypt certificate
 USE_HTTPS_LETSENCRYPT=False \
-GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=localhost \
+GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://localhost \
 # Set the number of Galaxy handlers
 GALAXY_HANDLER_NUMPROCS=2 \
 # Setting a standard encoding. This can get important for things like the unix sort tool.


### PR DESCRIPTION
I had problems when testing https://github.com/galaxyproject/tools-iuc/pull/1378/ the links from jbrowse were broken because of GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL not containing the scheme (see [here](https://github.com/galaxyproject/tools-iuc/pull/1378/files#diff-1aa143c7e46d808f79ed389dd7a6726cR315))

I *think* it's a better default like this, though I'm not 100% sure if it could create problems with IEs (I can't test right now...)