### PR TITLE
Makes ansible tags configurable on build time for compose/galaxy-web container

### DIFF
--- a/compose/galaxy-web/Dockerfile
+++ b/compose/galaxy-web/Dockerfile
@@ -6,6 +6,8 @@ FROM quay.io/bgruening/galaxy-base
 
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 
+ARG GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,cvmfs
+
 ENV GALAXY_DESTINATIONS_DEFAULT=slurm_cluster \
 # The following 2 ENV vars can be used to set the number of uwsgi processes and threads
 UWSGI_PROCESSES=2 \
@@ -66,7 +68,7 @@ RUN rm -f /usr/bin/startup && \
     # Used for detecting privileged mode
     --extra-vars host_docker_legacy=False \
     --extra-vars galaxy_extras_docker_legacy=False \
-    --tags=supervisor,startup,scripts,nginx,cvmfs -c local && \
+    --tags=$GALAXY_ANSIBLE_TAGS -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN chmod +x /usr/bin/startup


### PR DESCRIPTION
Hi there!

In order to run the ansible tasks with the `k8` label when building the compose/web container, I need to have the tags injectable. This allows runs like:

```
docker build --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8s -t pcm32/galaxy-web:k8s compose/galaxy-web/
```

I have narrowed down all required changes to only this one to be able to use these compose images with our helm deployments at https://github.com/galaxyproject/galaxy-kubernetes/tree/feature/sync_with_galaxy_stable. All the rest is handled to configuration files. 

