### PR TITLE
Replaces k8 with k8s for ansible parts

### DIFF
--- a/compose/buildlocal.sh
+++ b/compose/buildlocal.sh
@@ -2,7 +2,7 @@
 set -x -e
 
 ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
-ANSIBLE_RELEASE=86a127ae3aaaea125c8faa0271471106f2a4f889
+ANSIBLE_RELEASE=5d9c8be9b496a6890cf04a858ed650f0211baf89
 
 GALAXY_RELEASE=dev
 GALAXY_REPO=galaxyproject/galaxy

--- a/compose/galaxy-base/Dockerfile
+++ b/compose/galaxy-base/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:14.04
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 
 ARG ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
-ARG ANSIBLE_RELEASE=1e07cc8a56cd18821a9f20129c400a242d25d1a0
+ARG ANSIBLE_RELEASE=5d9c8be9b496a6890cf04a858ed650f0211baf89
 
 ENV DEBIAN_FRONTEND=noninteractive \
 GALAXY_USER=galaxy \

--- a/compose/galaxy-init/Dockerfile
+++ b/compose/galaxy-init/Dockerfile
@@ -40,7 +40,7 @@ RUN ansible-playbook /ansible/provision.yml \
     --extra-vars galaxy_config_file=$GALAXY_CONFIG_FILE \
     --extra-vars galaxy_extras_config_condor=True \
     --extra-vars galaxy_extras_config_condor_docker=True \
-    --extra-vars galaxy_extras_config_k8_jobs=True \
+    --extra-vars galaxy_extras_config_k8s_jobs=True \
     --extra-vars galaxy_minimum_version=17.09 \
     --extra-vars galaxy_extras_config_rabbitmq=False \
     --extra-vars nginx_upload_store_path=/export/nginx_upload_store \
@@ -50,7 +50,7 @@ RUN ansible-playbook /ansible/provision.yml \
     #--extra-vars container_resolution_explicit=True \
     #--extra-vars container_resolution_cached_mulled=False \
     #--extra-vars container_resolution_build_mulled=False \
-    --tags=ie,pbs,slurm,uwsgi,metrics,k8 -c local && \
+    --tags=ie,pbs,slurm,uwsgi,metrics,k8s -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 


### PR DESCRIPTION
A companion PR for https://github.com/galaxyproject/ansible-galaxy-extras/pull/178 to avoid breaking compatibility. This is to avoid to the confusions that k8 and k8s cause when using these deployments.

I'm waiting though for a commit sha from the ansible-galaxy-extras to update the set commit to be used on the Dockerfile for fetching the correct revision from that repo.