### PR TITLE
Uses :dev tag for FROMs in all relevant containers for compose

### DIFF
--- a/compose/buildlocal.sh
+++ b/compose/buildlocal.sh
@@ -9,15 +9,18 @@ GALAXY_REPO=galaxyproject/galaxy
 
 DOCKER_ADDITIONAL_BUILD_ARGS="--no-cache"
 
+# For using latest simply leave this variable empty or set to ":latest". This should be the case on the master branch.
+TAG=":dev"
+
 docker pull postgres
 
-docker build $DOCKER_ADDITIONAL_BUILD_ARGS --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t quay.io/bgruening/galaxy-base ./galaxy-base/
-docker build $DOCKER_ADDITIONAL_BUILD_ARGS --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t quay.io/bgruening/galaxy-init ./galaxy-init/
+docker build $DOCKER_ADDITIONAL_BUILD_ARGS --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t quay.io/bgruening/galaxy-base$TAG ./galaxy-base/
+docker build $DOCKER_ADDITIONAL_BUILD_ARGS --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t quay.io/bgruening/galaxy-init$TAG ./galaxy-init/
 
 # Build the Galaxy web-application container
-docker build $DOCKER_ADDITIONAL_BUILD_ARGS -t quay.io/bgruening/galaxy-web ./galaxy-web/
+docker build $DOCKER_ADDITIONAL_BUILD_ARGS -t quay.io/bgruening/galaxy-web$TAG ./galaxy-web/
 
-docker build $DOCKER_ADDITIONAL_BUILD_ARGS --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t quay.io/galaxy/proftpd ./galaxy-proftpd
+docker build $DOCKER_ADDITIONAL_BUILD_ARGS --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t quay.io/galaxy/proftpd$TAG ./galaxy-proftpd
 
 # Build the postgres container
 docker build -t quay.io/galaxy/postgres ./galaxy-postgres
@@ -26,7 +29,7 @@ docker build -t quay.io/galaxy/postgres ./galaxy-postgres
 docker build -t quay.io/galaxy/slurm ./galaxy-slurm
 
 # we build a common HTCondor and derive from that laster
-docker build -t quay.io/bgruening/galaxy-htcondor-base ./galaxy-htcondor-base
-docker build -t quay.io/bgruening/galaxy-htcondor ./galaxy-htcondor
-docker build -t quay.io/bgruening/galaxy-htcondor-executor ./galaxy-htcondor-executor
+docker build -t quay.io/bgruening/galaxy-htcondor-base$TAG ./galaxy-htcondor-base
+docker build -t quay.io/bgruening/galaxy-htcondor$TAG ./galaxy-htcondor
+docker build -t quay.io/bgruening/galaxy-htcondor-executor$TAG ./galaxy-htcondor-executor
 

--- a/compose/buildlocal.sh
+++ b/compose/buildlocal.sh
@@ -10,7 +10,7 @@ GALAXY_REPO=galaxyproject/galaxy
 DOCKER_ADDITIONAL_BUILD_ARGS="--no-cache"
 
 # For using latest simply leave this variable empty or set to ":latest". This should be the case on the master branch.
-TAG=":dev"
+TAG=":latest"
 
 docker pull postgres
 

--- a/compose/galaxy-htcondor-executor/Dockerfile
+++ b/compose/galaxy-htcondor-executor/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bgruening/galaxy-htcondor-base
+FROM quay.io/bgruening/galaxy-htcondor-base:dev
 
 ENV GALAXY_USER=galaxy \
 GALAXY_UID=1450 \

--- a/compose/galaxy-htcondor/Dockerfile
+++ b/compose/galaxy-htcondor/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bgruening/galaxy-htcondor-base
+FROM quay.io/bgruening/galaxy-htcondor-base:dev
 
 ADD condor_config.local /etc/condor/condor_config.local
 ADD supervisord.conf /etc/supervisord.conf

--- a/compose/galaxy-init/Dockerfile
+++ b/compose/galaxy-init/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION       Galaxy-central
 
-FROM quay.io/bgruening/galaxy-base
+FROM quay.io/bgruening/galaxy-base:dev
 
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 

--- a/compose/galaxy-web/Dockerfile
+++ b/compose/galaxy-web/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION       Galaxy-central
 
-FROM quay.io/bgruening/galaxy-base
+FROM quay.io/bgruening/galaxy-base:dev
 
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 


### PR DESCRIPTION
Currently all the compose containers have their `FROM` statements pointing to a `:latest` image implicitly, however when (docker) built in the development branch they get tagged with a `:dev` tag. This means that `:dev` containers are starting from `:latest` tags, when they should start `FROM` `:dev` ones. This PR alleviates that.

Didn't want to touch the non-compose ones.

We should probably have a release strategy here, where containers are tagged on release identifiers instead of relying so much on latest. Probably requires more discussion.