### PR TITLE
ISATools lite support

### DIFF
--- a/compose/galaxy-base/Dockerfile
+++ b/compose/galaxy-base/Dockerfile
@@ -6,9 +6,6 @@ FROM ubuntu:14.04
 
 MAINTAINER Björn A. Grüning, bjoern.gruening@gmail.com
 
-ARG ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
-ARG ANSIBLE_RELEASE=5d9c8be9b496a6890cf04a858ed650f0211baf89
-
 ENV DEBIAN_FRONTEND=noninteractive \
 GALAXY_USER=galaxy \
 GALAXY_UID=1450 \
@@ -95,6 +92,10 @@ ADD ./bashrc $GALAXY_HOME/.bashrc
 # Container Style
 ADD condor_config.local /etc/condor/condor_config.local
 # fetch ansible galaxy extras
+
+ARG ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
+ARG ANSIBLE_RELEASE=5d9c8be9b496a6890cf04a858ed650f0211baf89
+
 RUN mkdir -p /ansible/galaxyprojectdotorg.galaxyextras && cd /ansible/galaxyprojectdotorg.galaxyextras && wget -pO- https://api.github.com/repos/$ANSIBLE_REPO/tarball/$ANSIBLE_RELEASE | tar xvz --strip-components=1
 ADD provision.yml /ansible/provision.yml
 

--- a/compose/galaxy-init/Dockerfile
+++ b/compose/galaxy-init/Dockerfile
@@ -32,6 +32,8 @@ RUN mkdir -p /export /galaxy-export && \
 ADD config $GALAXY_ROOT/config
 ADD welcome /galaxy-export/welcome
 
+ARG ISATOOLS_LITE_INSTALL=False
+
 RUN ansible-playbook /ansible/provision.yml \
     --extra-vars galaxy_server_dir=$GALAXY_ROOT \
     --extra-vars galaxy_venv_dir=$GALAXY_VIRTUAL_ENV \
@@ -46,11 +48,12 @@ RUN ansible-playbook /ansible/provision.yml \
     --extra-vars nginx_upload_store_path=/export/nginx_upload_store \
     --extra-vars nginx_welcome_location=$NGINX_WELCOME_LOCATION \
     --extra-vars nginx_welcome_path=$NGINX_WELCOME_PATH \
+    --extra-vars isatools_lite_install=$ISATOOLS_LITE_INSTALL \
     #--extra-vars galaxy_extras_config_container_resolution=True \
     #--extra-vars container_resolution_explicit=True \
     #--extra-vars container_resolution_cached_mulled=False \
     #--extra-vars container_resolution_build_mulled=False \
-    --tags=ie,pbs,slurm,uwsgi,metrics,k8s -c local && \
+    --tags=ie,pbs,slurm,uwsgi,metrics,k8s,isatools -c local && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 


### PR DESCRIPTION
Adds support for ISATools lite, together with twinned PR at the ansible-galaxy-extras side, to allow the use of the isa-tab and isa-json recently contributed composite datatypes.

Moves the ansible repo ARGS after all the heavy installation part to ease the pain of developers trying changes to the ansible part.

Squashed commits:
[c86d85c] Support of isatools installation
[6ea1978] moves ansible args for faster image making when developing