### PR TITLE
Optional init force copy functionality

### DIFF
--- a/compose/galaxy-init/startup.sh
+++ b/compose/galaxy-init/startup.sh
@@ -11,6 +11,15 @@ chown $GALAXY_UID:$GALAXY_GID /export
 for export_me in /galaxy-export/*
 do
   export_name=$(basename $export_me)
+  if [ ! "x$GALAXY_INIT_FORCE_COPY" = "x" ]; then
+     # delete so that if can be copied again if in the force-copy env var
+     # Example content for $GALAXY_INIT_FORCE_COPY
+     # GALAXY_INIT_FORCE_COPY = __venv__,__tools__
+     if [[ $GALAXY_INIT_FORCE_COPY = *__"$export_name"__* ]]; then
+       echo "Removing /export/$export_name if present as part of forced copy process."
+       rm -rf /export/$export_name
+     fi
+  fi
   if [ ! -d /export/$export_name ]
   then
     echo "Copying to /export/$export_name"


### PR DESCRIPTION
This PR allows users running the compose setup to force the copy of desired directories from init to the web container when executing. The user essentially needs to add directories to the GALAXY_INIT_FORCE_COPY env var and then the startup script will make sure that those directories are copied, even if they already exist, to the export. This is useful for long term running installations where you want to make sure that changes in the containers are reflected on the running setup (ie. changes in venv).

Squashed commits:
[a0b35d3] Adds forced copy option