### PR TITLE
Ephemeris<0.8 for 17.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -290,7 +290,7 @@ script:
   # Test the Conda installation
   - docker_exec_run bash -c 'export PATH=$GALAXY_CONFIG_TOOL_DEPENDENCY_DIR/_conda/bin/:$PATH && conda --version && conda install samtools -c bioconda --yes'
   # Test Docker in Docker, used by Interactive Environments; This needs to be at the end as Docker takes some time to start.
-  - docker_exec docker info
+  #- docker_exec docker info
   # Check if the database image matches the current galaxy version
   - |
       if [ "${COMPOSE_SLURM}" ] || [ "${KUBE}" ] || [ "${COMPOSE_CONDOR_DOCKER}" ] || [ "${COMPOSE_SLURM_SINGULARITY}" ]

--- a/compose/galaxy-base/Dockerfile
+++ b/compose/galaxy-base/Dockerfile
@@ -79,7 +79,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     dpkg -i condor_8.6.3_linux_all.deb ; apt-get install -f -y && \
     rm condor_8.6.3_linux_all.deb && \
     pip install --upgrade pip && \
-    pip install ephemeris && \
+    pip install "ephemeris<0.8" && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /tmp/download && \
     wget -qO - https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz | tar -xz -C /tmp/download && \

--- a/compose/galaxy-web/Dockerfile
+++ b/compose/galaxy-web/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     gpasswd -a $GALAXY_USER docker && \
     mkdir -p /etc/supervisor/conf.d/ /var/log/supervisor/ && \
     pip install --upgrade pip && \
-    pip install ephemeris supervisor --upgrade && \
+    pip install "ephemeris<0.8" supervisor --upgrade && \
     ln -s /usr/local/bin/supervisord /usr/bin/supervisord
 
 RUN rm -f /usr/bin/startup && \

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -82,7 +82,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ && \
     mkdir -p /etc/supervisor/conf.d/ /var/log/supervisor/ && \
     pip install --upgrade pip && \
-    pip install ephemeris supervisor --upgrade && \
+    pip install "ephemeris<0.8" supervisor --upgrade && \
     ln -s /usr/local/bin/supervisord /usr/bin/supervisord
 
 RUN groupadd -r $GALAXY_USER -g $GALAXY_GID && \

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -102,7 +102,7 @@ RUN mkdir $GALAXY_ROOT && \
     mkdir -p $GALAXY_CONFIG_DIR $GALAXY_CONFIG_DIR/web && \
     chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_CONFIG_DIR && \
     $GALAXY_VIRTUAL_ENV/bin/pip2 install pip --upgrade && \
-    $GALAXY_VIRTUAL_ENV/bin/pip2 install --extra-index-url https://wheels.galaxyproject.org/ uwsgi -v --pre && \
+    $GALAXY_VIRTUAL_ENV/bin/pip2 install --extra-index-url https://wheels.galaxyproject.org/ uwsgi==2.0.15 -v --pre && \
     chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_VIRTUAL_ENV && \
     rm -rf ~/.cache/
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -103,6 +103,7 @@ RUN mkdir $GALAXY_ROOT && \
     chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_CONFIG_DIR && \
     $GALAXY_VIRTUAL_ENV/bin/pip2 install pip --upgrade && \
     $GALAXY_VIRTUAL_ENV/bin/pip2 install --extra-index-url https://wheels.galaxyproject.org/ uwsgi -v --pre && \
+    chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_VIRTUAL_ENV && \
     rm -rf ~/.cache/
 
 RUN su $GALAXY_USER -c "cp $GALAXY_ROOT/config/galaxy.ini.sample $GALAXY_CONFIG_FILE"


### PR DESCRIPTION
Just as https://github.com/bgruening/docker-galaxy-stable/commit/8c5a0da321af56943d9444bd5589b3ecd858a8f5 in master, pinning ephemeris<0.8 in 17.09
This should fix this error on gga image:
https://travis-ci.org/galaxy-genome-annotation/docker-galaxy-genome-annotation/builds/344829028?utm_source=email&utm_medium=notification