### PR TITLE
Update docker client version from 17.05 to 17.06.2 and fix download URL

### DIFF
--- a/compose/galaxy-base/Dockerfile
+++ b/compose/galaxy-base/Dockerfile
@@ -84,7 +84,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     pip install ephemeris && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /tmp/download && \
-    wget -qO - https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz | tar -xz -C /tmp/download && \
+    wget -qO - https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz | tar -xz -C /tmp/download && \
     mv /tmp/download/docker/docker /usr/bin/ && \
     rm -rf /tmp/download && \
     rm -rf ~/.cache/

--- a/compose/galaxy-htcondor-executor/Dockerfile
+++ b/compose/galaxy-htcondor-executor/Dockerfile
@@ -12,7 +12,7 @@ LANG=en_US.UTF-8
 ADD startup.sh /usr/bin/startup.sh
 
 RUN mkdir -p /tmp/download && \
-    wget --no-check-certificate -qO - https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz | tar -xz -C /tmp/download && \
+    wget --no-check-certificate -qO - https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz | tar -xz -C /tmp/download && \
     mv /tmp/download/docker/docker /usr/bin/ && \
     rm -rf /tmp/download && \
     rm -rf ~/.cache/ && \

--- a/compose/galaxy-slurm/Dockerfile
+++ b/compose/galaxy-slurm/Dockerfile
@@ -31,7 +31,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     mkdir /var/log/supervisor && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     mkdir -p /tmp/download && \
-    wget -qO - https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz | tar -xz -C /tmp/download && \
+    wget -qO - https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz | tar -xz -C /tmp/download && \
     mv /tmp/download/docker/docker /usr/bin/ && \
     rm -rf /tmp/download && \
     rm -rf ~/.cache/


### PR DESCRIPTION
Closes #441. I have not yet tested whether 17.06.2 is fully working and backwards compatible, but the build works again.