### PR TITLE
Introduces build-orchestration-images.sh as replacement for buildlocal.sh (to be deprecated)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,12 @@ before_install:
         INSTALL_REPO_ARG="--galaxy-url http://localhost:80"
         SAMPLE_TOOLS=/export/config/sample_tool_list.yaml
         cd "$WORKING_DIR"
-        ./buildlocal.sh
+        # For build script
+        export CONTAINER_REGISTRY=quay.io/
+        export CONTAINER_USER=bgruening
+        ./build-orchestration-images.sh --no-push > image-build.log
+        export TAG_POSTGRES=$(cat image-build.log | grep '^Postgres:' | awk -F':' '{ print $3 }' )
+        export TAG_PROFTPD=$(cat image-build.log | grep '^Proftpd:' | awk -F':' '{ print $3 }' )
         export COMPOSE_PROJECT_NAME=galaxy_compose
         docker-compose up -d
 
@@ -138,7 +143,7 @@ before_install:
             docker-compose stop galaxy-slurm
             sleep 30
         fi
-        
+
         if [ "${COMPOSE_SLURM}" ] || [ "${COMPOSE_SLURM_SINGULARITY}" ]
         then
             # turn down the htcondor services
@@ -150,7 +155,7 @@ before_install:
         if [ "${COMPOSE_SLURM_SINGULARITY}" ]
         then
             # docker-compose is already started and has pre-populated the /export dir
-            # we now turn it down again and copy in an example tool with tool_conf.xml and 
+            # we now turn it down again and copy in an example tool with tool_conf.xml and
             # a test singularity image. If we copy this from the beginning, the magic Docker Galax startup
             # script will not work as it detects something in /export/
             docker-compose down
@@ -174,7 +179,7 @@ before_install:
             parsec datasets show_dataset $OUTPUT_ID | jq .misc_info | grep singularity
 
         fi
-        
+
         docker-compose logs --tail 50
         # Define start functions
         docker_exec() {
@@ -255,7 +260,7 @@ script:
   - date > time.txt && curl -v --fail -T time.txt ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD || true
   # Test FTP Server get
   - curl -v --fail ftp://localhost:8021 --user $GALAXY_USER:$GALAXY_USER_PASSWD
-  
+
   # Test CVMFS
   - docker_exec bash -c "service autofs start"
   - docker_exec bash -c "cvmfs_config chksetup"

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ before_install:
         export CONTAINER_REGISTRY=quay.io/
         export CONTAINER_USER=bgruening
         ./build-orchestration-images.sh --no-push --condor --graphana --slurm --k8s 2> image-build.log
+        cat image-build.log
         export TAG_POSTGRES=$(cat image-build.log | grep '^Postgres:' | awk -F':' '{ print $3 }' )
         export TAG_PROFTPD=$(cat image-build.log | grep '^Proftpd:' | awk -F':' '{ print $3 }' )
         export TAG=$(cat image-build.log | grep '^Web:' | awk -F':' '{ print $3 }' )

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ before_install:
         # For build script
         export CONTAINER_REGISTRY=quay.io/
         export CONTAINER_USER=bgruening
-        ./build-orchestration-images.sh --no-push --condor --graphana --slurm --k8s
+        ./build-orchestration-images.sh --no-push --condor --grafana --slurm --k8s
         source ./tags-for-compose-to-source.sh
         export COMPOSE_PROJECT_NAME=galaxy_compose
         docker-compose up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,11 +123,8 @@ before_install:
         # For build script
         export CONTAINER_REGISTRY=quay.io/
         export CONTAINER_USER=bgruening
-        ./build-orchestration-images.sh --no-push --condor --graphana --slurm --k8s 2> image-build.log
-        cat image-build.log
-        export TAG_POSTGRES=$(cat image-build.log | grep '^Postgres:' | awk -F':' '{ print $3 }' )
-        export TAG_PROFTPD=$(cat image-build.log | grep '^Proftpd:' | awk -F':' '{ print $3 }' )
-        export TAG=$(cat image-build.log | grep '^Web:' | awk -F':' '{ print $3 }' )
+        ./build-orchestration-images.sh --no-push --condor --graphana --slurm --k8s
+        source ./tags-for-compose-to-source.sh
         export COMPOSE_PROJECT_NAME=galaxy_compose
         docker-compose up -d
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,9 +123,10 @@ before_install:
         # For build script
         export CONTAINER_REGISTRY=quay.io/
         export CONTAINER_USER=bgruening
-        ./build-orchestration-images.sh --no-push > image-build.log
+        ./build-orchestration-images.sh --no-push 2> image-build.log
         export TAG_POSTGRES=$(cat image-build.log | grep '^Postgres:' | awk -F':' '{ print $3 }' )
         export TAG_PROFTPD=$(cat image-build.log | grep '^Proftpd:' | awk -F':' '{ print $3 }' )
+        export TAG=$(cat image-build.log | grep '^Web:' | awk -F':' '{ print $3 }' )
         export COMPOSE_PROJECT_NAME=galaxy_compose
         docker-compose up -d
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -247,6 +247,11 @@ script:
         cd $TRAVIS_BUILD_DIR/test/gridengine/ && bash test.sh && cd $WORKING_DIR
       fi
   # Test Web api
+  - |
+      if [ "${COMPOSE_CONDOR_DOCKER}" ]
+      then
+        docker-compose logs --tail 50
+      fi
   - curl -v --fail $BIOBLEND_GALAXY_URL/api/version
 
   # Test self-signed HTTPS

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ before_install:
         # For build script
         export CONTAINER_REGISTRY=quay.io/
         export CONTAINER_USER=bgruening
-        ./build-orchestration-images.sh --no-push 2> image-build.log
+        ./build-orchestration-images.sh --no-push --condor --graphana --slurm --k8s 2> image-build.log
         export TAG_POSTGRES=$(cat image-build.log | grep '^Postgres:' | awk -F':' '{ print $3 }' )
         export TAG_PROFTPD=$(cat image-build.log | grep '^Proftpd:' | awk -F':' '{ print $3 }' )
         export TAG=$(cat image-build.log | grep '^Web:' | awk -F':' '{ print $3 }' )

--- a/compose/build-community-images-for-k8s.sh
+++ b/compose/build-community-images-for-k8s.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+# vi: fdm=marker
+
+set -e
+
+### Constants ###
+
+SCRIPT_NAME="${0##*/}"
+TRUE='true'
+FALSE='false'
+DFT_DOCKER_PUSH_ENABLED=$TRUE
+
+### Functions ###
+
+function log() {
+  echo -e "$@" >&2
+}
+
+function error {
+
+	local msg=$1
+	local code=$2
+	[[ -z $code ]] && code=1
+
+	log "[ERROR] $msg"
+
+	exit $code
+}
+
+
+function debug {
+
+    local msg=$1
+    local level=$2
+    [[ -n $level ]] || level=1
+
+    [[ $DEBUG -lt $level ]] || log "[DEBUG] $msg"
+}
+
+function warning {
+
+    local msg=$1
+
+    log "[WARNING] ##### $msg #####"
+}
+
+function print_help {
+    (
+        echo "Usage: $SCRIPT_NAME [options]"
+        echo
+        echo "Build Galaxy docker images for use with k8s."
+        echo
+        echo "Options:"
+        echo "   -g, --debug                    Debug mode. [false]"
+        echo "   -h, --help                     Print this help message."
+        echo "   -p, --push                     Push docker images. You can also set environment variable DOCKER_PUSH_ENABLED to \"true\". [true]"
+        echo "   +p, --no-push                  Do not push dockers. You can also set environment variable DOCKER_PUSH_ENABLED to \"false\"."
+        echo "       --push-intermediate        Also push intermediate images [false]"
+        echo "       --no-cache                 Tell Docker not to use cached images. [false]"
+        echo "       --init-tag       <tag>     Set the tag for the Galaxy Init Flavour container image."
+        echo "       --postgres-tag   <tag>     Set the tag for the Galaxy Postgres container image."
+        echo "       --proftpd-tag    <tag>     Set the tag for the Galaxy Proftpd container image."
+        echo "       --web-tag        <tag>     Set the tag for the Galaxy Web k8s container image."
+        echo "   -u, --container-user <user>    Set the container user. You can also set the environment variable CONTAINER_USER. [pcm32]"
+        echo "   -r, --container-registry <reg> Set the container registry. You can also set the environment variable CONTAINER_REGISTRY."
+        echo
+    ) >&2
+}
+
+function read_args {
+
+    local args="$*" # save arguments for debugging purpose
+
+    # Read options
+    while [[ $# > 0 ]] ; do
+        shift_count=1
+        case $1 in
+            -g|--debug)              DEBUG=$((DEBUG + 1)) ;;
+            -h|--help)               print_help ; exit 0 ;;
+            -p|--push)               DOCKER_PUSH_ENABLED=$TRUE ;;
+            +p|--no-push)            DOCKER_PUSH_ENABLED=$FALSE ;;
+            --push-intermediate)     PUSH_INTERMEDIATE_IMAGES=$TRUE ;;
+            --no-cache)              NO_CACHE="--no-cache" ;;
+            --postgres-tag)          OVERRIDE_POSTGRES_TAG="$2" ; shift_count=2 ;;
+            --proftpd-tag)           OVERRIDE_PROFTPD_TAG="$2" ; shift_count=2 ;;
+            --init-tag)              OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG="$2" ; shift_count=2 ;;
+            --web-tag)               OVERRIDE_GALAXY_WEB_K8S_TAG="$2" ; shift_count=2 ;;
+            -u|--container-user)     CONTAINER_USER="$2" ; shift_count=2 ;;
+            -r|--container-registry) CONTAINER_REGISTRY="$2" ; shift_count=2 ;;
+            *) error "Illegal option $1." 98 ;;
+        esac
+        shift $shift_count
+    done
+
+    # Debug messages
+    debug "Command line arguments: $args"
+    debug "Argument DEBUG=$DEBUG"
+    debug "Argument DOCKER_PUSH_ENABLED=$DOCKER_PUSH_ENABLED"
+    debug "Argument DOCKER_USER=$DOCKER_USER"
+    debug "Argument OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG=$OVERRIDE_GALAXY_INIT_PHENO_FLAVOURED_TAG"
+    debug "Argument OVERRIDE_GALAXY_WEB_K8S_TAG=$OVERRIDE_GALAXY_WEB_K8S_TAG"
+    debug "Argument OVERRIDE_POSTGRES_TAG=$OVERRIDE_POSTGRES_TAG"
+    debug "Argument OVERRIDE_PROFTPD_TAG=$OVERRIDE_PROFTPD_TAG"
+    debug "shift_count=$shift_count"
+}
+
+### MAIN ###
+
+read_args "$@"
+
+DOCKER_PUSH_ENABLED=${DOCKER_PUSH_ENABLED:-$DFT_DOCKER_PUSH_ENABLED}
+
+DOCKER_REPO=${CONTAINER_REGISTRY:-}
+DOCKER_USER=${CONTAINER_USER:-pcm32}
+
+ANSIBLE_REPO=${ANSIBLE_REPO:-galaxyproject/ansible-galaxy-extras}
+ANSIBLE_RELEASE=${ANSIBLE_RELEASE:-master}
+
+GALAXY_VERSION=18.05
+
+GALAXY_BASE_FROM_TO_REPLACE=${GALAXY_BASE_FROM_TO_REPLACE:-quay.io/bgruening/galaxy-base:$GALAXY_VERSION}
+
+GALAXY_RELEASE=${GALAXY_RELEASE:-release_$GALAXY_VERSION}
+GALAXY_REPO=${GALAXY_REPO:-galaxyproject/galaxy}
+
+GALAXY_VER_FOR_POSTGRES=$GALAXY_VERSION
+# Uncomment to push intermediate images, otherwise only the images needed for the helm chart are pushed.
+#PUSH_INTERMEDIATE_IMAGES=yes
+
+# Set tags
+TAG=v$GALAXY_VERSION
+
+if [[ -n ${CONTAINER_TAG_PREFIX:-} && -n ${BUILD_NUMBER:-} ]]; then
+    TAG=${CONTAINER_TAG_PREFIX}.${BUILD_NUMBER}
+fi
+
+GALAXY_BASE_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-base:$TAG
+GALAXY_INIT_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init:$TAG
+GALAXY_WEB_K8S_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
+
+if [[ -n "${DOCKER_REPO}" ]]; then
+    # Append slash, avoiding double slash
+    DOCKER_REPO="${DOCKER_REPO%/}/"
+fi
+
+if [[ -n "${OVERRIDE_GALAXY_WEB_K8S_TAG:-}" ]]; then
+    GALAXY_WEB_K8S_TAG="${OVERRIDE_GALAXY_WEB_K8S_TAG}"
+else
+    GALAXY_WEB_K8S_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-web-k8s:$TAG
+fi
+
+if [[ -n "${OVERRIDE_POSTGRES_TAG:-}" ]]; then
+    POSTGRES_TAG="${OVERRIDE_POSTGRES_TAG}"
+else
+    PG_Dockerfile="galaxy-postgres/Dockerfile"
+
+    [[ -f "${PG_Dockerfile}" ]] || error "The galaxy-postgres Dockerfile is missing under galaxy-Postgres." 99
+    POSTGRES_VERSION=$(grep FROM "${PG_Dockerfile}" | awk -F":" '{ print $2 }')
+
+    POSTGRES_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-postgres:$POSTGRES_VERSION"_for_"$GALAXY_VER_FOR_POSTGRES
+fi
+
+if [[ -n "${OVERRIDE_PROFTPD_TAG:-}" ]]; then
+    PROFTPD_TAG="${OVERRIDE_PROFTPD_TAG}"
+else
+    PROFTPD_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-proftpd:for_galaxy_v$GALAXY_VER_FOR_POSTGRES
+fi
+
+### do work
+
+if [ -n $ANSIBLE_REPO ]
+    then
+       log "Making custom galaxy-base:$TAG from $ANSIBLE_REPO at $ANSIBLE_RELEASE"
+       docker build $NO_CACHE --build-arg ANSIBLE_REPO=$ANSIBLE_REPO --build-arg ANSIBLE_RELEASE=$ANSIBLE_RELEASE -t $GALAXY_BASE_TAG galaxy-base/
+       if [[ ! -z ${PUSH_INTERMEDIATE_IMAGES+x} ]];
+       then
+	         log "Pushing intermediate image $DOCKER_REPO$DOCKER_USER/galaxy-base:$TAG"
+           docker push $GALAXY_BASE_TAG
+       fi
+fi
+
+
+if [ -n $GALAXY_REPO ]
+    then
+       log "Making custom galaxy-init:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+       DOCKERFILE_INIT_1=Dockerfile
+       if [ -n $ANSIBLE_REPO ]
+       then
+         sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_TAG+ galaxy-init/Dockerfile > galaxy-init/Dockerfile_init
+	       FROM=`grep ^FROM galaxy-init/Dockerfile_init | awk '{ print $2 }'`
+	       log "Using FROM $FROM for galaxy init"
+	       DOCKERFILE_INIT_1=Dockerfile_init
+       fi
+       docker build $NO_CACHE --build-arg GALAXY_REPO=$GALAXY_REPO --build-arg GALAXY_RELEASE=$GALAXY_RELEASE -t $GALAXY_INIT_TAG -f galaxy-init/$DOCKERFILE_INIT_1 galaxy-init/
+       if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+	       log "Pushing image $GALAXY_INIT_TAG"
+         docker push $GALAXY_INIT_TAG
+       fi
+fi
+
+# GALAXY_INIT_FLAVOURED_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init-flavoured:$TAG
+#
+# DOCKERFILE_INIT_FLAVOUR=Dockerfile_init
+# if [ -n $GALAXY_REPO ]
+# then
+# 	echo "Making custom galaxy-init-pheno-flavoured:$TAG starting from galaxy-init-pheno:$TAG"
+# 	sed s+pcm32/galaxy-init$+$GALAXY_INIT_PHENO_TAG+ Dockerfile_init > Dockerfile_init_tagged
+# 	DOCKERFILE_INIT_FLAVOUR=Dockerfile_init_tagged
+# fi
+# docker build $NO_CACHE -t $GALAXY_INIT_FLAVOURED_TAG -f $DOCKERFILE_INIT_FLAVOUR .
+# docker push $GALAXY_INIT_PHENO_FLAVOURED_TAG
+
+
+
+DOCKERFILE_WEB=Dockerfile
+if [ -n $GALAXY_REPO ]
+then
+	echo "Making custom galaxy-web-k8s:$TAG from $GALAXY_REPO at $GALAXY_RELEASE"
+	sed s+$GALAXY_BASE_FROM_TO_REPLACE+$GALAXY_BASE_TAG+ galaxy-web/Dockerfile > galaxy-web/Dockerfile_web
+	DOCKERFILE_WEB=Dockerfile_web
+fi
+docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx,k8,k8s -t $GALAXY_WEB_K8S_TAG -f galaxy-web/$DOCKERFILE_WEB galaxy-web/
+if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+  docker push $GALAXY_WEB_K8S_TAG
+fi
+
+# Build postgres
+docker build -t $POSTGRES_TAG -f galaxy-postgres/Dockerfile galaxy-postgres/
+if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+  docker push $POSTGRES_TAG
+fi
+
+# Build proftpd
+docker build -t $PROFTPD_TAG -f galaxy-proftpd/Dockerfile galaxy-proftpd/
+if [[ "${DOCKER_PUSH_ENABLED:-}" = "true" ]]; then
+  docker push $PROFTPD_TAG
+fi
+
+log "Relevant containers:"
+log "Web:          $GALAXY_WEB_K8S_TAG"
+log "Init:         $GALAXY_INIT_TAG"
+log "Postgres:     $POSTGRES_TAG"
+log "Proftpd:      $PROFTPD_TAG"
+
+log "Now build your Galaxy own galaxy init container starting from $GALAXY_INIT_TAG"

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -286,7 +286,7 @@ if $BUILD_FOR_K8S; then
   log " - Proftpd: $PROFTPD_TAG"
 fi
 
-cat > ./tags-for-compose-to-source.sh <<DELIM
+cat << DELIM > ./tags-for-compose-to-source.sh
 export TAG=$GALAXY_WEB_TAG
 export TAG_POSTGRES=$POSTGRES_TAG
 export TAG_PROFTPD=$PROFTPD_TAG

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -211,7 +211,7 @@ then
 	DOCKERFILE_WEB=Dockerfile_web
 fi
 K8S_ANSIBLE_TAGS=""
-if $BUILD_FOR_K8S;
+if $BUILD_FOR_K8S; then
   K8S_ANSIBLE_TAGS=,k8,k8s
 fi
 docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,scripts,nginx$K8S_ANSIBLE_TAGS -t $GALAXY_WEB_TAG -f galaxy-web/$DOCKERFILE_WEB galaxy-web/
@@ -267,7 +267,7 @@ if $BUILD_FOR_GRAPHANA; then
 fi
 
 log "Now build your own Galaxy init container starting FROM $GALAXY_INIT_TAG to add you own flavour, tools, workflows, etc."
-if $BUILD_FOR_K8S;
+if $BUILD_FOR_K8S; then
   log ""
   log "For k8s: Once you have built your own init container use it within the galaxy-stable Helm chart at https://github.com/galaxyproject/galaxy-kubernetes together with:"
   log " - Web: $GALAXY_WEB_TAG"

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -60,6 +60,7 @@ function print_help {
         echo "       --k8s                      Set settings for Kubernetes usage."
         echo "       --graphana                 Build graphana container."
         echo "       --condor                   Build condor containers."
+        echo "       --slurm                    Build slurm containers."
         echo "   -u, --container-user <user>    Set the container user. You can also set the environment variable CONTAINER_USER."
         echo "   -r, --container-registry <reg> Set the container registry. You can also set the environment variable CONTAINER_REGISTRY."
         echo
@@ -80,6 +81,7 @@ function read_args {
             +p|--no-push)            DOCKER_PUSH_ENABLED=$FALSE ;;
             --k8s)                   BUILD_FOR_K8S=$TRUE ;;
             --condor)                BUILD_FOR_CONDOR=$TRUE ;;
+            --slurm)                 BUILD_FOR_SLURM=$TRUE ;;
             --graphana)              BUILD_FOR_GRAPHANA=$TRUE ;;
             --push-intermediate)     PUSH_INTERMEDIATE_IMAGES=$TRUE ;;
             --no-cache)              NO_CACHE="--no-cache" ;;
@@ -109,6 +111,7 @@ function read_args {
 BUILD_FOR_K8S=$FALSE
 BUILD_FOR_CONDOR=$FALSE
 BUILD_FOR_GRAPHANA=$FALSE
+BUILD_FOR_SLURM=$FALSE
 
 read_args "$@"
 
@@ -170,6 +173,7 @@ CONDOR_BASE_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-htcondor-base:$TAG
 CONDOR_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-htcondor:$TAG
 CONDOR_EXEC_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-htcondor-executor:$TAG
 GRAPHANA_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-graphana:$TAG
+SLURM_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-slurm:$TAG
 ### do work
 
 if [ -n $ANSIBLE_REPO ]
@@ -248,6 +252,11 @@ if $BUILD_FOR_CONDOR; then
   fi
 fi
 
+# Build for slurm
+if $BUILD_FOR_SLURM; then
+  docker build -t $SLURM_TAG ./galaxy-slurm
+fi
+
 # Build for graphana
 if $BUILD_FOR_GRAPHANA; then
   docker build -t $GRAPHANA_TAG ./galaxy-grafana
@@ -262,6 +271,8 @@ if $BUILD_FOR_CONDOR; then
   log "Condor:       $CONDOR_TAG"
   log "Condor-exec:  $CONDOR_EXEC_TAG"
 fi
+if $BUILD_FOR_SLURM; then
+  log "Slurm:        $SLURM_TAG"
 if $BUILD_FOR_GRAPHANA; then
   log "Graphana:     $GRAPHANA_TAG"
 fi

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -58,7 +58,7 @@ function print_help {
         echo "       --proftpd-tag    <tag>     Set the tag for the Galaxy Proftpd container image."
         echo "       --web-tag        <tag>     Set the tag for the Galaxy Web k8s container image."
         echo "       --k8s                      Set settings for Kubernetes usage."
-        echo "       --graphana                 Build graphana container."
+        echo "       --grafana                  Build grafana container."
         echo "       --condor                   Build condor containers."
         echo "       --slurm                    Build slurm containers."
         echo "   -u, --container-user <user>    Set the container user. You can also set the environment variable CONTAINER_USER."
@@ -82,7 +82,7 @@ function read_args {
             --k8s)                   BUILD_FOR_K8S=$TRUE ;;
             --condor)                BUILD_FOR_CONDOR=$TRUE ;;
             --slurm)                 BUILD_FOR_SLURM=$TRUE ;;
-            --graphana)              BUILD_FOR_GRAPHANA=$TRUE ;;
+            --grafana)               BUILD_FOR_GRAFANA=$TRUE ;;
             --push-intermediate)     PUSH_INTERMEDIATE_IMAGES=$TRUE ;;
             --no-cache)              NO_CACHE="--no-cache" ;;
             --postgres-tag)          OVERRIDE_POSTGRES_TAG="$2" ; shift_count=2 ;;
@@ -110,7 +110,7 @@ function read_args {
 ### MAIN ###
 BUILD_FOR_K8S=$FALSE
 BUILD_FOR_CONDOR=$FALSE
-BUILD_FOR_GRAPHANA=$FALSE
+BUILD_FOR_GRAFANA=$FALSE
 BUILD_FOR_SLURM=$FALSE
 
 read_args "$@"
@@ -172,7 +172,7 @@ fi
 CONDOR_BASE_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-htcondor-base:$TAG
 CONDOR_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-htcondor:$TAG
 CONDOR_EXEC_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-htcondor-executor:$TAG
-GRAPHANA_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-graphana:$TAG
+GRAFANA_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-grafana:$TAG
 SLURM_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-slurm:$TAG
 ### do work
 
@@ -257,9 +257,9 @@ if $BUILD_FOR_SLURM; then
   docker build -t $SLURM_TAG ./galaxy-slurm
 fi
 
-# Build for graphana
-if $BUILD_FOR_GRAPHANA; then
-  docker build -t $GRAPHANA_TAG ./galaxy-grafana
+# Build for grafana
+if $BUILD_FOR_GRAFANA; then
+  docker build -t $GRAFANA_TAG ./galaxy-grafana
 fi
 
 log "Relevant containers:"
@@ -274,8 +274,8 @@ fi
 if $BUILD_FOR_SLURM; then
   log "Slurm:        $SLURM_TAG"
 fi
-if $BUILD_FOR_GRAPHANA; then
-  log "Graphana:     $GRAPHANA_TAG"
+if $BUILD_FOR_GRAFANA; then
+  log "Grafana:     $GRAFANA_TAG"
 fi
 
 log "Now build your own Galaxy init container starting FROM $GALAXY_INIT_TAG to add you own flavour, tools, workflows, etc."

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -241,11 +241,11 @@ if $BUILD_FOR_CONDOR; then
   sed s+$CONDOR_BASE_FROM_TO_REPLACE+$CONDOR_BASE_TAG+ galaxy-htcondor/Dockerfile > galaxy-htcondor/Dockerfile_condor
   FROM=`grep ^FROM galaxy-htcondor/Dockerfile_condor | awk '{ print $2 }'`
   log "Using FROM $FROM for condor"
-  docker build $NO_CACHE -t $CONDOR_TAG -f galaxy-htcondor/Docker_condor galaxy-htcondor/
+  docker build $NO_CACHE -t $CONDOR_TAG -f galaxy-htcondor/Dockerfile_condor galaxy-htcondor/
   sed s+$CONDOR_BASE_FROM_TO_REPLACE+$CONDOR_BASE_TAG+ galaxy-htcondor-executor/Dockerfile > galaxy-htcondor-executor/Dockerfile_condor
   FROM=`grep ^FROM galaxy-htcondor-executor/Dockerfile_condor | awk '{ print $2 }'`
   log "Using FROM $FROM for condor-executor"
-  docker build $NO_CACHE -t $CONDOR_EXEC_TAG -f galaxy-htcondor-executor/Docker_condor galaxy-htcondor-executor/
+  docker build $NO_CACHE -t $CONDOR_EXEC_TAG -f galaxy-htcondor-executor/Dockerfile_condor galaxy-htcondor-executor/
   if $DOCKER_PUSH_ENABLED; then
     docker push $CONDOR_TAG
     docker push $CONDOR_EXEC_TAG

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -289,5 +289,5 @@ fi
 cat > ./tags-for-compose-to-source.sh <<DELIM
 export TAG=$GALAXY_WEB_TAG
 export TAG_POSTGRES=$POSTGRES_TAG
-export TAG_PROFTPD=$PROFTPD_TAG"
+export TAG_PROFTPD=$PROFTPD_TAG
 DELIM

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -273,6 +273,7 @@ if $BUILD_FOR_CONDOR; then
 fi
 if $BUILD_FOR_SLURM; then
   log "Slurm:        $SLURM_TAG"
+fi
 if $BUILD_FOR_GRAPHANA; then
   log "Graphana:     $GRAPHANA_TAG"
 fi

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -285,3 +285,9 @@ if $BUILD_FOR_K8S; then
   log " - Postgres: $POSTGRES_TAG"
   log " - Proftpd: $PROFTPD_TAG"
 fi
+
+cat > ./tags-for-compose-to-source.sh <<DELIM
+export TAG=$GALAXY_WEB_TAG
+export TAG_POSTGRES=$POSTGRES_TAG
+export TAG_PROFTPD=$PROFTPD_TAG"
+DELIM

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -287,6 +287,6 @@ if $BUILD_FOR_K8S; then
   log " - Proftpd: $PROFTPD_TAG"
 fi
 
-echo "export TAG=$GALAXY_WEB_TAG" > tags-for-compose-to-source.sh
-echo "export TAG_POSTGRES=$POSTGRES_TAG" >> tags-for-compose-to-source.sh
-echo "export TAG_PROFTPD=$PROFTPD_TAG" >> tags-for-compose-to-source.sh
+echo "export TAG="$(echo $GALAXY_WEB_TAG | awk -F':' '{print $2}')  > tags-for-compose-to-source.sh
+echo "export TAG_POSTGRES="$(echo $POSTGRES_TAG | awk -F':' '{print $2}') >> tags-for-compose-to-source.sh
+echo "export TAG_PROFTPD="$(echo $PROFTPD_TAG | awk -F':' '{print $2}') >> tags-for-compose-to-source.sh

--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -286,8 +286,6 @@ if $BUILD_FOR_K8S; then
   log " - Proftpd: $PROFTPD_TAG"
 fi
 
-cat << DELIM > ./tags-for-compose-to-source.sh
-export TAG=$GALAXY_WEB_TAG
-export TAG_POSTGRES=$POSTGRES_TAG
-export TAG_PROFTPD=$PROFTPD_TAG
-DELIM
+echo "export TAG=$GALAXY_WEB_TAG" > tags-for-compose-to-source.sh
+echo "export TAG_POSTGRES=$POSTGRES_TAG" >> tags-for-compose-to-source.sh
+echo "export TAG_PROFTPD=$PROFTPD_TAG" >> tags-for-compose-to-source.sh

--- a/compose/buildlocal.sh
+++ b/compose/buildlocal.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -x -e
 
+echo "*****************  Notice **************************************************"
+echo "This script is deprecated, please use build-orchestration-images.sh instead."
+echo "*****************  Notice **************************************************"
+
 ANSIBLE_REPO=galaxyproject/ansible-galaxy-extras
 ANSIBLE_RELEASE=14c60b66f10326c7d158627b004d58e38ca503e4
 
@@ -35,3 +39,7 @@ docker build -t quay.io/bgruening/galaxy-htcondor$TAG ./galaxy-htcondor
 docker build -t quay.io/bgruening/galaxy-htcondor-executor$TAG ./galaxy-htcondor-executor
 
 docker build -t quay.io/bgruening/galaxy-grafana$TAG ./galaxy-grafana
+
+echo "*****************  Notice **************************************************"
+echo "This script is deprecated, please use build-orchestration-images.sh instead."
+echo "*****************  Notice **************************************************"

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # proftpd container
   galaxy-proftpd:
     # build: galaxy-proftpd
-    image: quay.io/bgruening/galaxy-proftpd:${TAG:-latest}
+    image: quay.io/bgruening/galaxy-proftpd:${TAG_PROFTPD:-latest}
     env_file: .env
     environment:
         - proftpd_db_connection=galaxy@galaxy-postgres
@@ -43,7 +43,7 @@ services:
     # If you are using the official postgres image, it needs to be populated by calling
     # docker-compose run galaxy install_db.sh
     # on first run
-    image: quay.io/bgruening/galaxy-postgres:${TAG:-latest}
+    image: quay.io/bgruening/galaxy-postgres:${TAG_POSTGRES:-latest}
     container_name: galaxy-postgres
     hostname: galaxy-postgres
     env_file: .env


### PR DESCRIPTION
An script for building the community images with all setting needed for Kubernetes (for 18.05). It allows to configure both Ansible and Galaxy repos/revision.