### PR TITLE
Detect init errors

### DIFF
--- a/compose/galaxy-init/startup.sh
+++ b/compose/galaxy-init/startup.sh
@@ -19,20 +19,23 @@ chown $GALAXY_UID:$GALAXY_GID /export
 for export_me in /galaxy-export/*
 do
   export_name=$(basename $export_me)
+  dest_path="/export/$export_name"
   if [ ! "x$GALAXY_INIT_FORCE_COPY" = "x" ]; then
      # delete so that if can be copied again if in the force-copy env var
      # Example content for $GALAXY_INIT_FORCE_COPY
      # GALAXY_INIT_FORCE_COPY = __venv__,__tools__
      if [[ $GALAXY_INIT_FORCE_COPY = *__"$export_name"__* ]]; then
-       echo "Removing /export/$export_name if present as part of forced copy process."
-       rm -rf /export/$export_name
+       echo "Removing ${dest_path} as part of forced copy process."
+       rm -rf "${dest_path}"
      fi
   fi
-  if [ ! -d /export/$export_name ]
+  if [ ! -d "${dest_path}" ]
   then
-    echo "Copying to /export/$export_name"
-    cp -rp $export_me /export/$export_name
-    chown -R $GALAXY_UID:$GALAXY_GID /export/$export_name
+    echo "Copying to ${dest_path}"
+    cp -rp "$export_me" "${dest_path}"
+    chown -R $GALAXY_UID:$GALAXY_GID "${dest_path}"
+  else
+    echo "Skipping $export_me (directory already and overwrite isn't forced)"
   fi
 done
 

--- a/compose/galaxy-init/startup.sh
+++ b/compose/galaxy-init/startup.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 # This script initializes the export directory if it isn't initialized already
 
+
+function error_trap() {
+  echo "#### Error at line ${BASH_LINENO[0]} running command ${BASH_COMMAND} ####" >&2
+}
+
+trap error_trap ERR
+set -o errexit
+
 echo "Initializing export"
 # Always copy current config to .distribution_config
 echo "Copying to /export/.distribution_config"
@@ -48,3 +56,5 @@ then
     echo "Init notified, sleeping now"
     sleep infinity
 fi
+
+exit 0


### PR DESCRIPTION
I've had some silent failures in the initialization phase. This PR makes the initialization script more defensive, enabling bash error checking and adding a minimal error trap that reports the failed command in case of errors.