### PR TITLE
Make init-galaxy-db.sh executable in PostgreSQL Docker image

### DIFF
--- a/compose/galaxy-postgres/Dockerfile
+++ b/compose/galaxy-postgres/Dockerfile
@@ -1,4 +1,5 @@
 FROM library/postgres:9.6.5
 ADD init-galaxy-db.sql.in /docker-entrypoint-initdb.d/
 ADD init-galaxy-db.sh /docker-entrypoint-initdb.d/
-RUN chmod a+rx /docker-entrypoint-initdb.d/init-galaxy-db.sh
+RUN chmod a+rx /docker-entrypoint-initdb.d/init-galaxy-db.sh && \
+    chmod a+r /docker-entrypoint-initdb.d/init-galaxy-db.sql.in

--- a/compose/galaxy-postgres/Dockerfile
+++ b/compose/galaxy-postgres/Dockerfile
@@ -1,4 +1,4 @@
 FROM library/postgres:9.6.5
 ADD init-galaxy-db.sql.in /docker-entrypoint-initdb.d/
 ADD init-galaxy-db.sh /docker-entrypoint-initdb.d/
-
+RUN chmod a+rx /docker-entrypoint-initdb.d/init-galaxy-db.sh


### PR DESCRIPTION
Fixes error when the image's docker-entrypoint.sh script tries executing
all scripts in /docker-entrypoint-initdb.d/, e.g.:

```
/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/init-galaxy-db.sh
/usr/local/bin/docker-entrypoint.sh: line 128: /docker-entrypoint-initdb.d/init-galaxy-db.sh: Permission denied
```