### PR TITLE
Preinstall bcftools conda env

### DIFF
--- a/compose/galaxy-init/Dockerfile
+++ b/compose/galaxy-init/Dockerfile
@@ -87,6 +87,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-x86
 # Install all required Node dependencies. This is required to get proxy support to work for Interactive Environments
 RUN export PATH=/tool_deps/_conda/bin/:$PATH && \
     conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5 && \
+    conda clean --tarballs --yes && \
     conda install -c conda-forge nodejs=9.11.1 yarn=1.12.1 git && \
     ./scripts/common_startup.sh --skip-client-build && \
     . $GALAXY_VIRTUAL_ENV/bin/activate && \

--- a/compose/galaxy-init/Dockerfile
+++ b/compose/galaxy-init/Dockerfile
@@ -86,6 +86,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-x86
 # prefetch Python wheels
 # Install all required Node dependencies. This is required to get proxy support to work for Interactive Environments
 RUN export PATH=/tool_deps/_conda/bin/:$PATH && \
+    conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5 && \
     conda install -c conda-forge nodejs=9.11.1 yarn=1.12.1 git && \
     ./scripts/common_startup.sh --skip-client-build && \
     . $GALAXY_VIRTUAL_ENV/bin/activate && \

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -105,6 +105,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-x86
     echo "conda activate base" >> $GALAXY_HOME/.bashrc && \
     export PATH=/tool_deps/_conda/bin/:$PATH && \
     conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5 && \
+    conda clean --tarballs --yes && \
     conda install virtualenv pip && \
     # conda install conda-canary::conda=4.6 && \
     chown $GALAXY_USER:$GALAXY_USER -R /tool_deps/ /etc/profile.d/conda.sh && \

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -104,6 +104,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-4.5.11-Linux-x86
     echo ". /tool_deps/_conda/etc/profile.d/conda.sh" >> $GALAXY_HOME/.bashrc && \
     echo "conda activate base" >> $GALAXY_HOME/.bashrc && \
     export PATH=/tool_deps/_conda/bin/:$PATH && \
+    conda create -y --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __bcftools@1.5 bcftools=1.5 && \
     conda install virtualenv pip && \
     # conda install conda-canary::conda=4.6 && \
     chown $GALAXY_USER:$GALAXY_USER -R /tool_deps/ /etc/profile.d/conda.sh && \
@@ -264,4 +265,3 @@ RUN chmod +x /usr/bin/install_db.sh
 
 # Autostart script that is invoked during container start
 CMD ["/usr/bin/startup"]
-


### PR DESCRIPTION
A fix for the #472 = preinstall the __bcftools@1.5 conda env in the docker image to prevent possible problems on first import of multiple datasets