### PR TITLE
Run dumpsql within build-orchestration-images

### DIFF
--- a/compose/build-orchestration-images.sh
+++ b/compose/build-orchestration-images.sh
@@ -153,6 +153,7 @@ GALAXY_BASE_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-base:$TAG
 GALAXY_INIT_TAG=$DOCKER_REPO$DOCKER_USER/galaxy-init:$TAG
 GALAXY_WEB_TAG=${OVERRIDE_GALAXY_WEB_TAG:-$DOCKER_REPO$DOCKER_USER/galaxy-web:$TAG}
 
+# Set postgres tag
 if [[ -n "${OVERRIDE_POSTGRES_TAG:-}" ]]; then
     POSTGRES_TAG="${OVERRIDE_POSTGRES_TAG}"
 else
@@ -226,6 +227,10 @@ docker build $NO_CACHE --build-arg GALAXY_ANSIBLE_TAGS=supervisor,startup,script
 if $DOCKER_PUSH_ENABLED; then
   docker push $GALAXY_WEB_TAG
 fi
+
+# Create dump for postgres based on init created here
+export GALAXY_INIT_TAG
+./dumpsql.sh
 
 # Build postgres
 docker build -t $POSTGRES_TAG -f galaxy-postgres/Dockerfile galaxy-postgres/

--- a/compose/dumpsql.sh
+++ b/compose/dumpsql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TAG=v18.09
+INIT_IMAGE=${GALAXY_INIT_TAG:-"quay.io/bgruening/galaxy-init:v18.09"}
 
 # Sets the image of postgres to use
 POSTGRES=postgres:9.6.5
@@ -26,7 +26,7 @@ init_start=`date +%s`
 docker run -i --rm --name "dumpsql_galaxy_installdb" \
     -e "GALAXY_CONFIG_FILE=/etc/galaxy/galaxy.yml" \
     -e "GALAXY_CONFIG_DATABASE_CONNECTION=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@db/$POSTGRES_DB?client_encoding=utf8" \
-    --link "dumpsql_postgres:db" quay.io/bgruening/galaxy-init:$TAG install_db.sh
+    --link "dumpsql_postgres:db" $INIT_IMAGE install_db.sh
 
 init_end=`date +%s`
 dump_start=`date +%s`


### PR DESCRIPTION
This PR runs dumpsql as part of the building script, making sure that the dump used on the containers is based on the galaxy-init image just created, avoiding any incongruences. 