### PR TITLE
Remove nginx upload store variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -216,7 +216,6 @@ before_install:
             -e GALAXY_CONFIG_ALLOW_LIBRARY_PATH_PASTE=True \
             -e GALAXY_CONFIG_ENABLE_USER_DELETION=True \
             -e GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES=True \
-            -e GALAXY_CONFIG_NGINX_UPLOAD_STORE \
             -v /tmp/:/tmp/ \
             quay.io/bgruening/galaxy
         sleep 30

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -146,7 +146,6 @@ RUN ansible-playbook /ansible/postgresql_provision.yml && \
     --extra-vars proftpd_use_sftp=True \
     --extra-vars galaxy_extras_docker_legacy=False \
     --extra-vars galaxy_minimum_version=18.01 \
-    --extra-vars nginx_upload_store_path=$EXPORT_DIR/nginx_upload_store \
     --extra-vars supervisor_postgres_config_path=$PG_CONF_DIR_DEFAULT/postgresql.conf \
     --extra-vars supervisor_postgres_autostart=false \
     --extra-vars nginx_use_remote_header=True \
@@ -183,8 +182,6 @@ GALAXY_CONFIG_FTP_UPLOAD_SITE=galaxy.docker.org \
 GALAXY_CONFIG_USE_PBKDF2=False \
 GALAXY_CONFIG_NGINX_X_ACCEL_REDIRECT_BASE=/_x_accel_redirect \
 GALAXY_CONFIG_NGINX_X_ARCHIVE_FILES_BASE=/_x_accel_redirect \
-GALAXY_CONFIG_NGINX_UPLOAD_STORE=$EXPORT_DIR/nginx_upload_store \
-GALAXY_CONFIG_NGINX_UPLOAD_PATH=/_upload \
 GALAXY_CONFIG_DYNAMIC_PROXY_MANAGE=False \
 GALAXY_CONFIG_VISUALIZATION_PLUGINS_DIRECTORY=config/plugins/visualizations \
 GALAXY_CONFIG_TRUST_IPYTHON_NOTEBOOK_CONVERSION=True \
@@ -264,4 +261,3 @@ RUN chmod +x /usr/bin/install_db.sh
 
 # Autostart script that is invoked during container start
 CMD ["/usr/bin/startup"]
-


### PR DESCRIPTION
A little patch to remove nginx upload store variables as it's disabled by default now (https://github.com/galaxyproject/ansible-galaxy-extras/blob/18.09/defaults/main.yml#L5)

Without this, we're forced to unset `GALAXY_CONFIG_NGINX_UPLOAD_STORE` as in https://github.com/bgruening/docker-galaxy-stable/blob/master/.travis.yml#L219, otherwise we get a permission denied error at startup when mounting /export
(I could also fix the permission denied.. but as I don't know what is the future of this upload store feature..)