### PR TITLE
[WIP] Fix 1901 build

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -83,7 +83,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ && \
     mkdir -p /etc/supervisor/conf.d/ /var/log/supervisor/ && \
     pip install --upgrade pip && \
-    pip install ephemeris supervisor --upgrade && \
+    pip install ephemeris==0.10.2 supervisor --upgrade && \
     rm -rf ~/.cache/ /galaxy-central/client/node_modules/ && \
     ln -s /usr/local/bin/supervisord /usr/bin/supervisord
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -72,7 +72,7 @@ RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup && \
     apt-add-repository -y ppa:ansible/ansible && \
     apt-add-repository -y ppa:galaxyproject/nginx && \
     apt-get update -qq && apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y postgresql-9.3 sudo \
+    apt-get install --no-install-recommends -y postgresql-9.3 postgresql-server-dev-all sudo \
     nginx-extras=1.4.6-1ubuntu3.8ppa1 nginx-common=1.4.6-1ubuntu3.8ppa1 docker-ce=17.09.0~ce-0~ubuntu slurm-llnl slurm-llnl-torque \
     slurm-drmaa-dev proftpd proftpd-mod-pgsql libyaml-dev ansible munge libmunge-dev \
     nano vim curl python-crypto python-pip python-psutil condor python-ldap autofs \
@@ -115,8 +115,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-4.5.12-Linux-x86
     # Setup Galaxy configuration files.
     mkdir -p $GALAXY_CONFIG_DIR $GALAXY_CONFIG_DIR/web && \
     chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_CONFIG_DIR && \
-    $GALAXY_VIRTUAL_ENV/bin/pip2 install pip --upgrade && \
-    $GALAXY_VIRTUAL_ENV/bin/pip2 install --extra-index-url https://wheels.galaxyproject.org/ uwsgi==2.0.15 -v --pre && \
+    $GALAXY_VIRTUAL_ENV/bin/pip install pip --upgrade && \
+    $GALAXY_VIRTUAL_ENV/bin/pip install --extra-index-url https://wheels.galaxyproject.org/ uwsgi==2.0.15 -v --pre && \
     chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_VIRTUAL_ENV && \
     rm -rf ~/.cache/ /galaxy-central/client/node_modules/ && \
     su $GALAXY_USER -c "cp $GALAXY_ROOT/config/galaxy.yml.sample $GALAXY_CONFIG_FILE"


### PR DESCRIPTION
Trying to build the image for release 19.01, I faced quite many several errors, related to different issues but globally related to package dependencies.

* Build was failing due to ephemeris 0.10.3 which requires galaxy-tool-util instead of galaxy-lib. But galaxy-tool-util has only 19.09 pre-releases and result in build failure. Forcing ephemeris to previous release to fix issue
* pip2 command not found, use pip
* psycopg2 needs postgresql-server-dev-all package to install

Still getting an issue with sqlite3 node install:

    CXX(target) Release/obj.target/node_sqlite3/src/database.o
    In file included from ../../nan/nan.h:192:0,
                 from ../src/database.h:10,
                 from ../src/database.cc:4:
    ../../nan/nan_maybe_43_inl.h: In function ‘Nan::Maybe<bool> Nan::ForceSet(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Value>, 
    v8::PropertyAttribute)’:
    ../../nan/nan_maybe_43_inl.h:112:15: error: ‘class v8::Object’ has no member named ‘ForceSet’


Next image based on a more recent Ubuntu may fix the issue....

nan sub dependency needs to be either upgraded/downgraded, or get a more recent sqlite3 package version. Anyway, node fails to compile node sqlite3 module....