### PR TITLE
Change galaxy user shell to /bin/bash

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -106,7 +106,7 @@ RUN groupadd -r postgres -g $GALAXY_POSTGRES_GID \
     # we will recreate this later
     ## && rm -rf $PG_DATA_DIR_DEFAULT \
     && groupadd -r $GALAXY_USER -g $GALAXY_GID \
-    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" $GALAXY_USER \
+    && useradd -u $GALAXY_UID -r -g $GALAXY_USER -d $GALAXY_HOME -c "Galaxy user" --shell /bin/bash $GALAXY_USER \
     && mkdir $EXPORT_DIR $GALAXY_HOME $GALAXY_LOGS_DIR && chown -R $GALAXY_USER:$GALAXY_USER $GALAXY_HOME $EXPORT_DIR $GALAXY_LOGS_DIR \
     # cleanup dance
     && find /usr/lib/ -name '*.pyc' -delete \

--- a/test/bioblend/Dockerfile
+++ b/test/bioblend/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /home/galaxy
 ENV TOX_ENV=py27 \
     BIOBLEND_GALAXY_API_KEY=admin \
     BIOBLEND_GALAXY_URL=http://galaxy \
-    BIOBLEND_TEST_JOB_TIMEOUT="240"
+    BIOBLEND_TEST_JOB_TIMEOUT="240" \
+    GALAXY_VERSION=release_19.05
 
 RUN mkdir bioblend-master \
     && curl -L -s https://github.com/galaxyproject/bioblend/archive/master.tar.gz | tar xzf - --strip-components=1 -C bioblend-master \

--- a/test/bioblend/test.sh
+++ b/test/bioblend/test.sh
@@ -13,6 +13,7 @@ then
     export BIOBLEND_GALAXY_API_KEY=admin ;
     export BIOBLEND_GALAXY_URL=http://galaxy ;
     export BIOBLEND_TEST_JOB_TIMEOUT="240";
+    export GALAXY_VERSION=release_19.05;
     cd /home/galaxy/bioblend-master ;
     tox -e $TOX_ENV -- -k "not test_download_dataset and not test_upload_from_galaxy_filesystem and not test_get_datasets and not test_datasets_from_fs and not test_existing_history and not test_new_history and not test_params and not test_tool_dependency_install and not test_download_history and not test_export_and_download"'
 


### PR DESCRIPTION
In 19.05 the shell for the galaxy user changed from /bin/bash to /bin/sh
Unless there's a specific reason for that change, it would be great to switch back to /bin/bash