### PR TITLE
Fix 19.09 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 
 language: python
-python: 2.7
+python: 3.5
 
 services:
   - docker
@@ -146,7 +146,7 @@ before_install:
         ./build-orchestration-images.sh --no-push --condor --grafana --slurm --k8s
         source ./tags-for-compose-to-source.sh
 
-        container_size_check   quay.io/bgruening/galaxy-base:$TAG               350 
+        container_size_check   quay.io/bgruening/galaxy-base:$TAG               350
         container_size_check   quay.io/bgruening/galaxy-web:$TAG                650
         container_size_check   quay.io/bgruening/galaxy-htcondor-base:$TAG      280
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   matrix:
-    - TOX_ENV=py27
+    - TOX_ENV=py35
     - COMPOSE_SLURM=True
     - COMPOSE_SLURM_SINGULARITY=True
     # Compose version with Condor submitting Docker jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 sudo: required
 
 language: python
-python: 3.5
+python: 3.6
 
 services:
   - docker
 
 env:
   matrix:
-    - TOX_ENV=py35
+    - TOX_ENV=py36
     - COMPOSE_SLURM=True
     - COMPOSE_SLURM_SINGULARITY=True
     # Compose version with Condor submitting Docker jobs

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -286,6 +286,10 @@ ADD welcome.html $GALAXY_CONFIG_DIR/web/welcome.html
     #npm install && \
     #rm -rf ~/.cache/ $GALAXY_ROOT/client/node_modules/
 
+# This is a dead symlink in 19.09, triggering an error when creating /export at startup
+# See https://github.com/galaxyproject/galaxy/pull/9292
+RUN rm /galaxy-central/lib/galaxy/web/framework/static/toolshed/src
+
 # Switch back to User root
 USER root
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -286,9 +286,6 @@ ADD welcome.html $GALAXY_CONFIG_DIR/web/welcome.html
     #npm install && \
     #rm -rf ~/.cache/ $GALAXY_ROOT/client/node_modules/
 
-# change the default location of shed_tools to be ../shed_tools
-RUN sed -i 's|database|..|' $GALAXY_ROOT/config/shed_tool_conf.xml
-
 # Switch back to User root
 USER root
 

--- a/test/bioblend/Dockerfile
+++ b/test/bioblend/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/bgruening/galaxy
 USER galaxy
 WORKDIR /home/galaxy
 
-ENV TOX_ENV=py35 \
+ENV TOX_ENV=py36 \
     BIOBLEND_GALAXY_API_KEY=admin \
     BIOBLEND_GALAXY_URL=http://galaxy \
     BIOBLEND_TEST_JOB_TIMEOUT="240" \

--- a/test/bioblend/Dockerfile
+++ b/test/bioblend/Dockerfile
@@ -1,5 +1,8 @@
 FROM quay.io/bgruening/galaxy
 
+RUN apt-get -qq update && apt-get install --no-install-recommends -y python3-distutils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/
+
 USER galaxy
 WORKDIR /home/galaxy
 
@@ -13,8 +16,6 @@ RUN mkdir bioblend-master \
     && curl -L -s https://github.com/galaxyproject/bioblend/archive/master.tar.gz | tar xzf - --strip-components=1 -C bioblend-master \
     && cd bioblend-master \
     && export PATH=/tool_deps/_conda/bin/:$PATH && . activate galaxy_env \
-    && apt-get -qq update && apt-get install --no-install-recommends -y python3-distutils \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ \
     && pip install --upgrade "tox>=1.8.0" "pep8<=1.6.2" \
     && python setup.py install \
     && sed -i.bak "s/commands.*$/commands =/" tox.ini \

--- a/test/bioblend/Dockerfile
+++ b/test/bioblend/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir bioblend-master \
     && curl -L -s https://github.com/galaxyproject/bioblend/archive/master.tar.gz | tar xzf - --strip-components=1 -C bioblend-master \
     && cd bioblend-master \
     && export PATH=/tool_deps/_conda/bin/:$PATH && . activate galaxy_env \
+    && apt-get -qq update && apt-get install --no-install-recommends -y python3-distutils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ \
     && pip install --upgrade "tox>=1.8.0" "pep8<=1.6.2" \
     && python setup.py install \
     && sed -i.bak "s/commands.*$/commands =/" tox.ini \

--- a/test/bioblend/Dockerfile
+++ b/test/bioblend/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/bgruening/galaxy
 USER galaxy
 WORKDIR /home/galaxy
 
-ENV TOX_ENV=py27 \
+ENV TOX_ENV=py35 \
     BIOBLEND_GALAXY_API_KEY=admin \
     BIOBLEND_GALAXY_URL=http://galaxy \
     BIOBLEND_TEST_JOB_TIMEOUT="240" \

--- a/test/bioblend/test.sh
+++ b/test/bioblend/test.sh
@@ -9,7 +9,7 @@ then
     python setup.py install ;
     sed -i.bak "s/commands.*$/commands =/" tox.ini ;
     sed -i.bak2 "s/GALAXY_VERSION/GALAXY_VERSION BIOBLEND_TEST_JOB_TIMEOUT/" tox.ini ;
-    export TOX_ENV=py35 ;
+    export TOX_ENV=py36 ;
     export BIOBLEND_GALAXY_API_KEY=admin ;
     export BIOBLEND_GALAXY_URL=http://galaxy ;
     export BIOBLEND_TEST_JOB_TIMEOUT="240";

--- a/test/bioblend/test.sh
+++ b/test/bioblend/test.sh
@@ -9,7 +9,7 @@ then
     python setup.py install ;
     sed -i.bak "s/commands.*$/commands =/" tox.ini ;
     sed -i.bak2 "s/GALAXY_VERSION/GALAXY_VERSION BIOBLEND_TEST_JOB_TIMEOUT/" tox.ini ;
-    export TOX_ENV=py27 ;
+    export TOX_ENV=py35 ;
     export BIOBLEND_GALAXY_API_KEY=admin ;
     export BIOBLEND_GALAXY_URL=http://galaxy ;
     export BIOBLEND_TEST_JOB_TIMEOUT="240";


### PR DESCRIPTION
With this change I managed to build the 19.09 all-in-one image locally, and do basic stuff (upload, run a tool, install a tool)
There's a workaround for https://github.com/galaxyproject/galaxy/pull/9292

shed_tool_conf.xml gets created on first tool install, and it contains this:

`<toolbox tool_path="/galaxy-central/database/shed_tools">`

I don't remember exactly why there was this sed command. It looks like /galaxy-central/database is a symlink to /export/galaxy-central/database/, so I think it's the right path in shed_tool_conf.xml?