### PR TITLE
Use PyCurl for communicating with Pulsar (over REST)

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -146,11 +146,11 @@ jobs:
             options: --scale slurm_node=3
             exclude_test:
               - workflow_example1
-          # - name: galaxy-pulsar
-          #   files: -f docker-compose.yml -f docker-compose.pulsar.yml
-          #   exclude_test:
-          #     - workflow_example1
-          #     - workflow_mapping_by_sequencing
+          - name: galaxy-pulsar
+            files: -f docker-compose.yml -f docker-compose.pulsar.yml
+            exclude_test:
+              - workflow_example1
+              - workflow_mapping_by_sequencing
           # - name: galaxy-pulsar-mq
           #   files: -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml
           #   exclude_test:

--- a/compose/docker-compose.pulsar.yml
+++ b/compose/docker-compose.pulsar.yml
@@ -11,6 +11,7 @@ services:
   galaxy-configurator:
     environment:
       - GALAXY_JOB_RUNNER=pulsar_rest
+      - GALAXY_PULSAR_TRANSPORT=${GALAXY_PULSAR_TRANSPORT:-curl}
       - PULSAR_OVERWRITE_CONFIG=true
       - PULSAR_JOB_RUNNER=local
       - PULSAR_CONFIG_PRIVATE_TOKEN=changemeinproduction

--- a/compose/galaxy-configurator/templates/galaxy/job_conf.xml.j2
+++ b/compose/galaxy-configurator/templates/galaxy/job_conf.xml.j2
@@ -7,7 +7,9 @@
         <plugin id="slurm" type="runner" load="galaxy.jobs.runners.slurm:SlurmJobRunner">
             <param id="drmaa_library_path">/usr/lib/slurm-drmaa/lib/libdrmaa.so</param>
         </plugin>
-        <plugin id="pulsar_rest" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner"/>
+        <plugin id="pulsar_rest" type="runner" load="galaxy.jobs.runners.pulsar:PulsarRESTJobRunner">
+            <param id="transport">{{ GALAXY_PULSAR_TRANSPORT | default('curl') }}</param>
+        </plugin>
         {% if GALAXY_JOB_RUNNER == 'pulsar_mq' -%}
         <plugin id="pulsar_mq" type="runner" load="galaxy.jobs.runners.pulsar:PulsarMQJobRunner">
             <param id="galaxy_url">{{ PULSAR_GALAXY_URL }}</param>

--- a/compose/galaxy-server/Dockerfile
+++ b/compose/galaxy-server/Dockerfile
@@ -54,13 +54,13 @@ RUN curl -s -L "https://repo.anaconda.com/miniconda/Miniconda2-${MINICONDA_VERSI
 FROM build_base as build_galaxy
 COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 # Install Galaxy
-RUN apt update && apt install --no-install-recommends python3-dev python3-pip -y \
+RUN apt update && apt install --no-install-recommends libcurl4-openssl-dev libssl-dev python3-dev python3-pip -y \
     && mkdir "${GALAXY_ROOT}" \
     && curl -L -s $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT \
     && cd $GALAXY_ROOT \
     && ./scripts/common_startup.sh \
     && . $GALAXY_ROOT/.venv/bin/activate \
-    && pip3 install drmaa psycopg2 \
+    && pip3 install drmaa psycopg2 pycurl \
     && deactivate \
     && rm -rf .ci .circleci .coveragerc .gitignore .travis.yml CITATION CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md \
               LICENSE.txt Makefile README.rst SECURITY_POLICY.md pytest.ini tox.ini \
@@ -105,7 +105,8 @@ RUN groupadd -r $GALAXY_USER -g $GALAXY_GID \
     && /usr/bin/common_cleanup.sh
 
 # Install remaining dependencies
-RUN apt update && apt install --no-install-recommends gcc gnupg2 libgomp1 liblzma-dev libbz2-dev libpq-dev \
+RUN apt update && apt install --no-install-recommends curl gcc gnupg2 libgomp1 liblzma-dev libbz2-dev libpq-dev \
+                                                      libcurl4-openssl-dev libssl-dev \
                                                       mercurial make netcat python3-dev python3-setuptools python3-pip \
                                                       zlib1g-dev -y \
     # Cython and wheel are needed to later install pysam..


### PR DESCRIPTION
Currently, the standard transport option for communicating with Pulsar over the REST API seems to be incompatible with Python 3 (see https://github.com/galaxyproject/pulsar/issues/227). This PR introduces the environment variable `GALAXY_PULSAR_TRANSPORT` which allows to set the transport option on the Galaxy side. It defaults now to `curl`, which also allows us to re-enable the Pulsar REST integration tests.

I added `GALAXY_PULSAR_TRANSPORT` directly into the docker-compose file so testing different transport methods (maybe for CI?) is as easy as `export GALAXY_PULSAR_TRANSPORT=urllib`.