### PR TITLE
:sparkles: Introduce Kubernetes runner

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -83,6 +83,7 @@ jobs:
           - name: galaxy-htcondor
           - name: galaxy-slurm
           - name: galaxy-slurm-node-discovery
+          - name: galaxy-kind
           - name: pulsar
           - name: galaxy-configurator
           - name: galaxy-bioblend-test
@@ -159,6 +160,13 @@ jobs:
           #   exclude_test:
           #     - workflow_example1
           #     - workflow_mapping_by_sequencing
+          - name: galaxy-k8s
+            files: -f docker-compose.yml -f docker-compose.k8s.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - selenium
           - name: galaxy-singularity
             files: -f docker-compose.yml -f docker-compose.singularity.yml
             exclude_test:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,13 @@ jobs:
           #   exclude_test:
           #     - workflow_example1
           #     - workflow_mapping_by_sequencing
+          - name: galaxy-k8s
+            files: -f docker-compose.yml -f docker-compose.k8s.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - selenium
           - name: galaxy-singularity
             files: -f docker-compose.yml -f docker-compose.singularity.yml
             exclude_test:

--- a/compose/docker-compose.htcondor.yml
+++ b/compose/docker-compose.htcondor.yml
@@ -1,6 +1,6 @@
 # Extend Galaxy to run jobs using HTCondor.
 # Example: `docker-compose -f docker-compose.yml -f docker-compose.htcondor.yml up`
-version: '3'
+version: "3.7"
 services:
   galaxy-configurator:
     environment:

--- a/compose/docker-compose.k8s.yml
+++ b/compose/docker-compose.k8s.yml
@@ -1,0 +1,31 @@
+# Extend Galaxy to run jobs on Kubernetes.
+# This will set up Kubernetes using kind (https://kind.sigs.k8s.io).
+# Note that this extension is not compatible with others like Pulsar, HTCondor, Singularity, etc.
+# Example: `docker-compose -f docker-compose.yml -f docker-compose.k8s.yml up`
+version: "3.7"
+services:
+  galaxy-configurator:
+    environment:
+      - KIND_OVERWRITE_CONFIG=true
+      - GALAXY_JOB_RUNNER=k8s
+      - GALAXY_KUBECONFIG=/kind/.kube/config_in_docker
+    volumes:
+      - ${EXPORT_DIR:-./export}/kind:/kind
+  galaxy-server:
+    volumes:
+      - ${EXPORT_DIR:-./export}/kind:/kind
+    networks:
+      - kind
+  galaxy-kind:
+    image: ${DOCKER_REGISTRY:-quay.io}/${DOCKER_REGISTRY_USERNAME:-bgruening}/galaxy-kind:${IMAGE_TAG:-latest}
+    build: galaxy-kind
+    privileged: true
+    volumes:
+      - ${EXPORT_DIR:-./export}/kind:/kind
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - galaxy
+      - kind
+networks:
+  kind:
+    name: kind

--- a/compose/docker-compose.pulsar.mq.yml
+++ b/compose/docker-compose.pulsar.mq.yml
@@ -2,7 +2,7 @@
 # for communicating with Galaxy.
 # Requirements: `docker-compose.pulsar.yml`
 # Example: `docker-compose -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml up`
-version: "3"
+version: "3.7"
 services:
   galaxy-configurator:
     environment:

--- a/compose/docker-compose.pulsar.yml
+++ b/compose/docker-compose.pulsar.yml
@@ -6,7 +6,7 @@
 # communicate over HTTP. To enable the MQ, concatinate the
 # docker-compose.pulsar.mq.yml after this one.
 # Example: `docker-compose -f docker-compose.yml -f docker-compose.pulsar.yml up`
-version: "3"
+version: "3.7"
 services:
   galaxy-configurator:
     environment:

--- a/compose/docker-compose.singularity.yml
+++ b/compose/docker-compose.singularity.yml
@@ -5,7 +5,7 @@
 # Examples:
 #  * `docker-compose -f docker-compose.yml -f docker-compose.singularity.yml up`
 #  * `docker-compose -f docker-compose.yml -f docker-compose.slurm.yml -f docker-compose.singularity.yml up`
-version: '3'
+version: "3.7"
 services:
   galaxy-configurator:
     environment:

--- a/compose/docker-compose.singularity.yml
+++ b/compose/docker-compose.singularity.yml
@@ -9,6 +9,5 @@ version: "3.7"
 services:
   galaxy-configurator:
     environment:
-      - HOST_PWD=$PWD
       - GALAXY_DEPENDENCY_RESOLUTION=singularity
       - GALAXY_CONFIG_CONDA_AUTO_INSTALL=false

--- a/compose/docker-compose.slurm.yml
+++ b/compose/docker-compose.slurm.yml
@@ -1,6 +1,6 @@
 # Extend Galaxy to run jobs using Slurm.
 # Example: `docker-compose -f docker-compose.yml -f docker-compose.slurm.yml up`
-version: "3"
+version: "3.7"
 services:
   galaxy-configurator:
     environment:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     build: galaxy-configurator
     environment:
       - EXPORT_DIR=${EXPORT_DIR:-./export}
+      - HOST_PWD=$PWD
       - GALAXY_OVERWRITE_CONFIG=true
       - GALAXY_DEPENDENCY_RESOLUTION=conda
       - GALAXY_JOB_RUNNER=local

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3.7"
 services:
   galaxy-server:
     image: ${DOCKER_REGISTRY:-quay.io}/${DOCKER_REGISTRY_USERNAME:-bgruening}/galaxy-server:${IMAGE_TAG:-latest}

--- a/compose/galaxy-configurator/run.sh
+++ b/compose/galaxy-configurator/run.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Set default config dirs
+export GALAXY_CONF_DIR=${GALAXY_CONF_DIR:-/galaxy/config} \
+       NGINX_CONF_DIR=${NGINX_CONF_DIR:-/etc/nginx/} \
+       SLURM_CONF_DIR=${SLURM_CONF_DIR:-/etc/slurm-llnl} \
+       HTCONDOR_CONF_DIR=${HTCONDOR_CONF_DIR:-/htcondor} \
+       PULSAR_CONF_DIR=${PULSAR_CONF_DIR:-/pulsar/config} \
+       KIND_CONF_DIR=${KIND_CONF_DIR:-/kind}
 # Nginx configuration
 if [ "$NGINX_OVERWRITE_CONFIG" != "true" ]; then
   echo "NGINX_OVERWRITE_CONFIG is not true. Skipping configuration of Nginx"
@@ -10,8 +17,8 @@ else
     echo "Configuring $conf"
     j2 --customize /customize.py --undefined -o "/tmp/$conf" "/templates/nginx/$conf.j2" /base_config.yml
     echo "The following changes will be applied to $conf:"
-    diff "${NGINX_CONFIG_DIR:-/etc/nginx/}/$conf" "/tmp/$conf"
-    mv -f "/tmp/$conf" "${NGINX_CONFIG_DIR:-/etc/nginx}/$conf"
+    diff "${NGINX_CONF_DIR}/$conf" "/tmp/$conf"
+    mv -f "/tmp/$conf" "${NGINX_CONF_DIR}/$conf"
   done
 fi
 
@@ -20,18 +27,18 @@ if [ "$SLURM_OVERWRITE_CONFIG" != "true" ]; then
   echo "SLURM_OVERWRITE_CONFIG is not true. Skipping configuration of Slurm"
 else
   echo "Locking Slurm config"
-  touch "${SLURM_CONFIG_DIR:-/etc/slurm-llnl}/configurator.lock"
+  touch "${SLURM_CONF_DIR:-/etc/slurm-llnl}/configurator.lock"
   slurm_configs=( "slurm.conf" )
 
   for conf in "${slurm_configs[@]}"; do
     echo "Configuring $conf"
     j2 --customize /customize.py --undefined -o "/tmp/$conf" "/templates/slurm/$conf.j2" /base_config.yml
     echo "The following changes will be applied to $conf:"
-    diff "${SLURM_CONFIG_DIR:-/etc/slurm-llnl}/$conf" "/tmp/$conf"
-    mv -f "/tmp/$conf" "${SLURM_CONFIG_DIR:-/etc/slurm-llnl}/$conf"
+    diff "${SLURM_CONF_DIR}/$conf" "/tmp/$conf"
+    mv -f "/tmp/$conf" "${SLURM_CONF_DIR}/$conf"
   done
 
-  rm "${SLURM_CONFIG_DIR:-/etc/slurm-llnl}/configurator.lock"
+  rm "${SLURM_CONF_DIR}/configurator.lock"
   echo "Lock for Slurm config released"
 fi
 
@@ -40,18 +47,18 @@ if [ "$HTCONDOR_OVERWRITE_CONFIG" != "true" ]; then
   echo "HTCONDOR_OVERWRITE_CONFIG is not true. Skipping configuration of HTCondor"
 else
   echo "Locking HTCondor config"
-  touch "${HTCONDOR_CONFIG_DIR:-/htcondor}/configurator.lock"
+  touch "${HTCONDOR_CONF_DIR:-/htcondor}/configurator.lock"
   htcondor_configs=( "galaxy.conf" "master.conf" "executor.conf" )
 
   for conf in "${htcondor_configs[@]}"; do
     echo "Configuring $conf"
     j2 --customize /customize.py --undefined -o "/tmp/$conf" "/templates/htcondor/$conf.j2" /base_config.yml
     echo "The following changes will be applied to $conf:"
-    diff "${HTCONDOR_CONFIG_DIR:-/htcondor}/$conf" "/tmp/$conf"
-    mv -f "/tmp/$conf" "${HTCONDOR_CONFIG_DIR:-/htcondor}/$conf"
+    diff "${HTCONDOR_CONF_DIR}/$conf" "/tmp/$conf"
+    mv -f "/tmp/$conf" "${HTCONDOR_CONF_DIR}/$conf"
   done
 
-  rm "${HTCONDOR_CONFIG_DIR:-/htcondor}/configurator.lock"
+  rm "${HTCONDOR_CONF_DIR}/configurator.lock"
   echo "Lock for HTCondor config released"
 fi
 
@@ -60,18 +67,18 @@ if [ "$PULSAR_OVERWRITE_CONFIG" != "true" ]; then
   echo "PULSAR_OVERWRITE_CONFIG is not true. Skipping configuration of Pulsar"
 else
   echo "Locking Pulsar config"
-  touch "${PULSAR_CONFIG_DIR:-/pulsar/config}/configurator.lock"
+  touch "${PULSAR_CONF_DIR:-/pulsar/config}/configurator.lock"
   pulsar_configs=( "server.ini" "app.yml" "dependency_resolvers_conf.xml" )
 
   for conf in "${pulsar_configs[@]}"; do
     echo "Configuring $conf"
     j2 --customize /customize.py --undefined -o "/tmp/$conf" "/templates/pulsar/$conf.j2" /base_config.yml
     echo "The following changes will be applied to $conf:"
-    diff "${PULSAR_CONFIG_DIR:-/pulsar/config}/$conf" "/tmp/$conf"
-    mv -f "/tmp/$conf" "${PULSAR_CONFIG_DIR:-/pulsar/config}/$conf"
+    diff "${PULSAR_CONF_DIR}/$conf" "/tmp/$conf"
+    mv -f "/tmp/$conf" "${PULSAR_CONF_DIR}/$conf"
   done
 
-  rm "${PULSAR_CONFIG_DIR:-/pulsar/config}/configurator.lock"
+  rm "${PULSAR_CONF_DIR}/configurator.lock"
   echo "Lock for Pulsar config released"
 fi
 
@@ -81,7 +88,7 @@ if [ "$GALAXY_OVERWRITE_CONFIG" != "true" ]; then
   exit 0
 fi
 
-cd "${GALAXY_CONFIG_DIR:-/galaxy/config}" || { echo "Error: Could not find Galaxy config dir"; exit 1; }
+cd "${GALAXY_CONF_DIR}" || { echo "Error: Could not find Galaxy config dir"; exit 1; }
 
 echo "Waiting for Galaxy config dir to be initially populated (in case of first startup)"
 until [ "$(ls -p | grep -v /)" != "" ] && echo Galaxy config populated; do
@@ -99,8 +106,8 @@ for conf in "${galaxy_configs[@]}"; do
   echo "Configuring $conf"
   j2 --customize /customize.py --undefined -o "/tmp/$conf" "/templates/galaxy/$conf.j2" /base_config.yml
   echo "The following changes will be applied to $conf:"
-  diff "${GALAXY_CONFIG_DIR:-/galaxy/config}/$conf" "/tmp/$conf"
-  mv -f "/tmp/$conf" "${GALAXY_CONFIG_DIR:-/galaxy/config}/$conf"
+  diff "${GALAXY_CONF_DIR}/$conf" "/tmp/$conf"
+  mv -f "/tmp/$conf" "${GALAXY_CONF_DIR}/$conf"
 done
 
 echo "Finished configuring Galaxy"

--- a/compose/galaxy-configurator/templates/galaxy/job_conf.xml.j2
+++ b/compose/galaxy-configurator/templates/galaxy/job_conf.xml.j2
@@ -38,7 +38,7 @@
               {% if GALAXY_JOB_RUNNER == 'local' -%}
                 <param id="docker_volumes">{{ HOST_EXPORT_DIR }}/$galaxy_root:$galaxy_root:ro,{{ HOST_EXPORT_DIR }}/$tool_directory:$tool_directory:ro,{{ HOST_EXPORT_DIR }}/$job_directory:$job_directory:rw,{{ HOST_EXPORT_DIR }}/$working_directory:$working_directory:rw,{{ HOST_EXPORT_DIR }}/$default_file_path:$default_file_path:rw</param>
               {% endif -%}
-            {% elif not GALAXY_JOB_RUNNER.startswith('pulsar') -%}
+            {% elif not GALAXY_JOB_RUNNER.startswith('pulsar') and GALAXY_JOB_RUNNER != 'k8s' -%}
               <env file="/galaxy/.venv/bin/activate" />
             {% endif -%}
             {% if GALAXY_JOB_RUNNER == 'pulsar_rest' -%}

--- a/compose/galaxy-configurator/templates/galaxy/job_conf.xml.j2
+++ b/compose/galaxy-configurator/templates/galaxy/job_conf.xml.j2
@@ -19,6 +19,12 @@
             <param id="amqp_publish_retry">True</param>
         </plugin>
         {% endif -%}
+        {% if GALAXY_JOB_RUNNER == 'k8s' -%}
+        <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
+          <param id="k8s_config_path">{{ GALAXY_KUBECONFIG }}</param>
+          <param id="k8s_persistent_volume_claims">{{ GALAXY_K8S_PVC | default('galaxy-root:/galaxy,galaxy-database:/galaxy/database,galaxy-tool-deps:/tool_deps') }}</param>
+        </plugin>
+        {% endif -%}
     </plugins>
     <destinations default="{{ GALAXY_DEPENDENCY_RESOLUTION | default('conda') }}_{{ GALAXY_JOB_RUNNER | default('local') }}">
         <destination id="local" runner="local">
@@ -48,6 +54,13 @@
             {% endif -%}
             {% if GALAXY_JOB_RUNNER == 'pulsar_mq' -%}
               <param id="jobs_directory">{{ PULSAR_JOBS_DIRECTORY | default('/pulsar/files/staging/') }}</param>
+            {% endif -%}
+            {% if GALAXY_JOB_RUNNER == 'k8s' -%}
+              <param id="docker_repo_default">{{ GALAXY_K8S_DOCKER_REPO_DEFAULT | default('docker.io') }}</param>
+              {% if GALAXY_K8S_DOCKER_OWNER_DEFAULT -%}<param id="docker_owner_default">{{ GALAXY_K8S_DOCKER_OWNER_DEFAULT }}</param>{% endif -%}
+              <param id="docker_image_default">{{ GALAXY_K8S_DOCKER_IMAGE_DEFAULT | default('ubuntu') }}</param>
+              <param id="docker_tag_default">{{ GALAXY_K8S_DOCKER_TAG_DEFAULT | default('18.04') }}</param>
+              <param id="docker_enabled">true</param>
             {% endif -%}
         </destination>
     </destinations>

--- a/compose/galaxy-configurator/templates/kind/k8s_config/persistent_volumes.yml.j2
+++ b/compose/galaxy-configurator/templates/kind/k8s_config/persistent_volumes.yml.j2
@@ -1,0 +1,41 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: galaxy-root
+spec:
+  storageClassName: standard
+  capacity:
+    storage: {{ KIND_PV_STORAGE_SIZE | default(100) }}Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: {{ HOST_EXPORT_DIR }}/galaxy
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: galaxy-database
+spec:
+  storageClassName: standard
+  capacity:
+    storage: {{ KIND_PV_STORAGE_SIZE | default(100) }}Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: {{ HOST_EXPORT_DIR }}/galaxy/database
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: galaxy-tool-deps
+spec:
+  storageClassName: standard
+  capacity:
+    storage: {{ KIND_PV_STORAGE_SIZE | default(100) }}Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: {{ HOST_EXPORT_DIR }}/tool_deps

--- a/compose/galaxy-configurator/templates/kind/k8s_config/pv_claims.yml.j2
+++ b/compose/galaxy-configurator/templates/kind/k8s_config/pv_claims.yml.j2
@@ -1,0 +1,38 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: galaxy-root
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteMany
+  volumeName: galaxy-root
+  resources:
+    requests:
+      storage: {{ KIND_PV_STORAGE_SIZE | default(100) }}Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: galaxy-database
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteMany
+  volumeName: galaxy-database
+  resources:
+    requests:
+      storage: {{ KIND_PV_STORAGE_SIZE | default(100) }}Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: galaxy-tool-deps
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteMany
+  volumeName: galaxy-tool-deps
+  resources:
+    requests:
+      storage: {{ KIND_PV_STORAGE_SIZE | default(100) }}Gi

--- a/compose/galaxy-configurator/templates/kind/kind_config.yml.j2
+++ b/compose/galaxy-configurator/templates/kind/kind_config.yml.j2
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: {{ HOST_EXPORT_DIR }}/galaxy
+    containerPath: {{ HOST_EXPORT_DIR }}/galaxy
+  - hostPath: {{ HOST_EXPORT_DIR }}/tool_deps
+    containerPath: {{ HOST_EXPORT_DIR }}/tool_deps
+{% set kind_node_count = KIND_NODE_COUNT | default(1) | int -%}
+{% for i in range(1, kind_node_count + 1) -%}
+- role: worker
+  extraMounts:
+  - hostPath: {{ HOST_EXPORT_DIR }}/galaxy
+    containerPath: {{ HOST_EXPORT_DIR }}/galaxy
+  - hostPath: {{ HOST_EXPORT_DIR }}/tool_deps
+    containerPath: {{ HOST_EXPORT_DIR }}/tool_deps
+{% endfor %}

--- a/compose/galaxy-kind/Dockerfile
+++ b/compose/galaxy-kind/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.11
+
+ARG KIND_RELEASE=v0.8.1
+ARG KUBECTL_RELEASE=v1.18.3
+
+RUN apk add --no-cache docker
+
+RUN apk add --no-cache --virtual build-deps wget \
+    && apk add --no-cache bash \
+    && wget -O /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_RELEASE}/kind-linux-amd64 \
+    && chmod +x /usr/bin/kind \
+    && wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl \
+    && chmod +x /usr/bin/kubectl \
+    && apk del build-deps
+
+ENV KIND_CONFIG_DIR=/kind
+ENV KUBECONFIG=${KIND_CONFIG_DIR}/.kube/config
+
+COPY docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
+
+ENTRYPOINT [ "/usr/bin/docker-entrypoint.sh" ]

--- a/compose/galaxy-kind/docker-entrypoint.sh
+++ b/compose/galaxy-kind/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+_term() {
+  echo "Caught SIGTERM signal!"
+  echo "Trying to stop Kind cluster"
+  kind delete cluster --name "${K8S_CLUSTER_NAME:-galaxy}" || true
+  exit 0
+}
+trap _term SIGTERM
+
+if [ -z "$KIND_SKIP_CONFIG_LOCK" ]; then
+  sleep 2
+  echo "Waiting for Galaxy configurator to finish and release lock"
+  until [ ! -f "$KIND_CONFIG_DIR/configurator.lock" ] && echo Lock released; do
+  sleep 0.1;
+  done;
+fi
+rm "${KUBECONFIG}_in_docker" || true
+
+kind delete cluster --name "${K8S_CLUSTER_NAME:-galaxy}" || true
+kind create cluster --config "$KIND_CONFIG_DIR/kind_config.yml" --kubeconfig "$KUBECONFIG" --name "${K8S_CLUSTER_NAME:-galaxy}" || true
+
+# Create custom kubeconfig, that allows to reach the control-plane from inside the containers
+REAL_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${K8S_CLUSTER_NAME:-galaxy}-control-plane")
+cp "${KUBECONFIG}" "${KUBECONFIG}_in_docker"
+sed -i "s/127.0.0.1:[0-9]*$/${REAL_IP}:6443/g" "${KUBECONFIG}_in_docker"
+
+export KUBECONFIG="${KUBECONFIG}_in_docker"
+kubectl cluster-info
+
+# Not all resources can be easily updated, therefore it is easier
+# to remove the resources first, while the whole setup is
+# still starting up
+ls "$KIND_CONFIG_DIR/k8s_config"
+kubectl delete -f "$KIND_CONFIG_DIR/k8s_config" || true
+kubectl apply -f "$KIND_CONFIG_DIR/k8s_config"
+
+# Wait for SIGTERM and delete cluster
+sleep inf & wait

--- a/compose/galaxy-server/Dockerfile
+++ b/compose/galaxy-server/Dockerfile
@@ -60,7 +60,7 @@ RUN apt update && apt install --no-install-recommends libcurl4-openssl-dev libss
     && cd $GALAXY_ROOT \
     && ./scripts/common_startup.sh \
     && . $GALAXY_ROOT/.venv/bin/activate \
-    && pip3 install drmaa psycopg2 pycurl \
+    && pip3 install drmaa psycopg2 pycurl pykube \
     && deactivate \
     && rm -rf .ci .circleci .coveragerc .gitignore .travis.yml CITATION CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md \
               LICENSE.txt Makefile README.rst SECURITY_POLICY.md pytest.ini tox.ini \

--- a/compose/galaxy-server/files/start.sh
+++ b/compose/galaxy-server/files/start.sh
@@ -90,12 +90,15 @@ until nc -z -w 2 postgres 5432 && echo Postgres started; do
   sleep 1;
 done;
 
-if [ -f "/htcondor_config/galaxy.conf" ]; then
-  echo "HTCondor config file found"
+if [ "$SKIP_LOCKING" != "true" ]; then
   echo "Waiting for Galaxy configurator to finish and release lock"
-  until [ ! -f /config/configurator.lock ] && echo Lock released; do
+  until [ ! -f "$GALAXY_CONFIG_DIR/configurator.lock" ] && echo Lock released; do
     sleep 0.1;
   done;
+fi
+
+if [ -f "/htcondor_config/galaxy.conf" ]; then
+  echo "HTCondor config file found"
 
   cp -f "/htcondor_config/galaxy.conf" /etc/condor/condor_config.local
   echo "Starting HTCondor.."
@@ -115,7 +118,7 @@ if [[ -n $GALAXY_DEFAULT_ADMIN_USER ]]; then
 fi
 
 # Ensure proper permission (the configurator might have changed them "by mistake")
-chown -R "$GALAXY_USER:$GALAXY_GROUP" "$GALAXY_CONFIG_DIR"
+chown -RL "$GALAXY_USER:$GALAXY_GROUP" "$GALAXY_CONFIG_DIR"
 
 echo "Starting Galaxy now.."
 cd "$GALAXY_ROOT" || { echo "Error: Could not change to $GALAXY_ROOT"; exit 1; }

--- a/compose/galaxy-server/files/start.sh
+++ b/compose/galaxy-server/files/start.sh
@@ -114,6 +114,9 @@ if [[ -n $GALAXY_DEFAULT_ADMIN_USER ]]; then
   create_user &
 fi
 
+# Ensure proper permission (the configurator might have changed them "by mistake")
+chown -R "$GALAXY_USER:$GALAXY_GROUP" "$GALAXY_CONFIG_DIR"
+
 echo "Starting Galaxy now.."
 cd "$GALAXY_ROOT" || { echo "Error: Could not change to $GALAXY_ROOT"; exit 1; }
 "$GALAXY_VIRTUAL_ENV/bin/uwsgi" --yaml "$GALAXY_CONFIG_DIR/galaxy.yml" --uid "$GALAXY_UID" --gid "$GALAXY_GID"

--- a/compose/tests/docker-compose.test.bioblend.yml
+++ b/compose/tests/docker-compose.test.bioblend.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 services:
   galaxy-bioblend-test:
     image: ${DOCKER_REGISTRY:-quay.io}/${DOCKER_REGISTRY_USERNAME:-bgruening}/galaxy-bioblend-test:${IMAGE_TAG:-latest}

--- a/compose/tests/docker-compose.test.selenium.yml
+++ b/compose/tests/docker-compose.test.selenium.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 services:
   galaxy-selenium-test:
     image: ${DOCKER_REGISTRY:-quay.io}/${DOCKER_REGISTRY_USERNAME:-bgruening}/galaxy-selenium-test:${IMAGE_TAG:-latest}

--- a/compose/tests/docker-compose.test.workflows.yml
+++ b/compose/tests/docker-compose.test.workflows.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 services:
   galaxy-workflow-test:
     image: ${DOCKER_REGISTRY:-quay.io}/${DOCKER_REGISTRY_USERNAME:-bgruening}/galaxy-workflow-test:${IMAGE_TAG:-latest}

--- a/compose/tests/docker-compose.test.yml
+++ b/compose/tests/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 services:
   galaxy-configurator:
     environment:


### PR DESCRIPTION
Using the docker-compose.k8s.yml extension it is now possible to run jobs using Kubernetes. [Kind](https://kind.sigs.k8s.io) (Kubernetes in Docker) is responsible for starting up Kubernetes. The configurator will set the needed configs for Kind and the k8s persistent volume (claims).

This introduces the `galaxy-kind` container that is responsible for running kind to start up an k8s cluster and apply the configurations to it. It will also delete the cluster when docker-compose stops.

Other changes:
* Clean up Configurator
  * set defaults for environment variables centrally
  * Lock all configs on start
* Update compose files: 3 -> 3.7