### PR TITLE
CI: Tests for Pull Requests & small fixes

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -247,6 +247,8 @@ jobs:
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
+              echo "Removing export directory";
+              sudo rm -rf export
               continue;
             else
               exit $test_exit_code;
@@ -284,8 +286,11 @@ jobs:
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
             error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
+              echo "Removing export directory";
+              sudo rm -rf export
               continue;
             else
               exit $test_exit_code;

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -26,6 +26,7 @@ jobs:
           image_name: galaxy-container-base
         run: |
           for i in 1 2; do
+            set +e
             docker buildx build  \
             --output "type=image,name=${{ secrets.docker_registry }}/${{ secrets.docker_registry_username }}/$image_name:${{ steps.image_tag.outputs.image_tag }},push=true" \
             --build-arg IMAGE_TAG=${{ steps.image_tag.outputs.image_tag }} \
@@ -61,6 +62,7 @@ jobs:
           image_name: galaxy-cluster-base
         run: |
           for i in 1 2; do
+            set +e
             docker buildx build  \
             --output "type=image,name=${{ secrets.docker_registry }}/${{ secrets.docker_registry_username }}/$image_name:${{ steps.image_tag.outputs.image_tag }},push=true" \
             --build-arg IMAGE_TAG=${{ steps.image_tag.outputs.image_tag }} \
@@ -111,6 +113,7 @@ jobs:
       - name: Run Buildx
         run: |
           for i in 1 2; do
+            set +e
             docker buildx build \
             --output "type=image,name=${{ secrets.docker_registry }}/${{ secrets.docker_registry_username }}/${{ matrix.image.name }}:${{ steps.image_tag.outputs.image_tag }},push=true" \
             --build-arg IMAGE_TAG=${{ steps.image_tag.outputs.image_tag }} \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,204 @@
+name: pr-test
+on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        infrastructure:
+          - name: galaxy-base
+            files: -f docker-compose.yml
+            exclude_test:
+              - workflow_example1
+          - name: galaxy-proxy-prefix
+            files: -f docker-compose.yml
+            env: GALAXY_PROXY_PREFIX=/arbitrary_Galaxy-prefix GALAXY_CONFIG_GALAXY_INFRASTRUCTURE_URL=http://localhost/arbitrary_Galaxy-prefix
+            exclude_test:
+              - workflow_example1
+          - name: galaxy-htcondor
+            files: -f docker-compose.yml -f docker-compose.htcondor.yml
+            exclude_test:
+              - workflow_example1
+          - name: galaxy-slurm
+            files: -f docker-compose.yml -f docker-compose.slurm.yml
+            env: SLURM_NODE_COUNT=3
+            options: --scale slurm_node=3
+            exclude_test:
+              - workflow_example1
+          - name: galaxy-pulsar
+            files: -f docker-compose.yml -f docker-compose.pulsar.yml
+            exclude_test:
+              - workflow_example1
+              - workflow_mapping_by_sequencing
+          # - name: galaxy-pulsar-mq
+          #   files: -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml
+          #   exclude_test:
+          #     - workflow_example1
+          #     - workflow_mapping_by_sequencing
+          - name: galaxy-singularity
+            files: -f docker-compose.yml -f docker-compose.singularity.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - selenium
+          # - name: galaxy-pulsar-mq-singularity
+          #   files: -f docker-compose.yml -f docker-compose.pulsar.yml -f docker-compose.pulsar.mq.yml -f docker-compose.singularity.yml
+          #   exclude_test:
+          #     - bioblend
+          #     - workflow_ard
+          #     - workflow_mapping_by_sequencing
+          #     - selenium
+          - name: galaxy-slurm-singularity
+            files: -f docker-compose.yml -f docker-compose.slurm.yml -f docker-compose.singularity.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - selenium
+          - name: galaxy-htcondor-singularity
+            files: -f docker-compose.yml -f docker-compose.htcondor.yml -f docker-compose.singularity.yml
+            exclude_test:
+              - bioblend
+              - workflow_ard
+              - workflow_mapping_by_sequencing
+              - selenium
+        test:
+          - name: bioblend
+            files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.bioblend.yml
+            exit-from: galaxy-bioblend-test
+            timeout: 60
+            second_run: "true"
+          - name: workflow_ard
+            files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.workflows.yml
+            exit-from: galaxy-workflow-test
+            workflow: sklearn/ard/ard.ga
+            timeout: 60
+            second_run: "true"
+          - name: workflow_mapping_by_sequencing
+            files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.workflows.yml
+            exit-from: galaxy-workflow-test
+            workflow: training/variant-analysis/mapping-by-sequencing/mapping_by_sequencing.ga
+            timeout: 60
+          - name: workflow_example1
+            files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.workflows.yml
+            exit-from: galaxy-workflow-test
+            workflow: example1/wf3-shed-tools.ga
+            timeout: 60
+          - name: selenium
+            files: -f tests/docker-compose.test.yml -f tests/docker-compose.test.selenium.yml
+            exit-from: galaxy-selenium-test
+            timeout: 60
+      fail-fast: false
+    steps:
+      # Self-made `exclude` as Github Actions currently does not support
+      # exclude/including of dicts in matrices
+      - name: Check if test should be run
+        id: run_check
+        if: contains(matrix.infrastructure.exclude_test, matrix.test.name) != true
+        run: echo ::set-output name=run::true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set WORKFLOWS env for worfklows-test
+        if: matrix.test.workflow
+        run: echo "::set-env name=WORKFLOWS::${{ matrix.test.workflow }}"
+      - name: Build galaxy-container-base
+        env:
+          image_name: galaxy-container-base
+        run: |
+          docker buildx build  \
+            --output "type=image,name=quay.io/bgruening/$image_name:ci-testing" \
+            --build-arg IMAGE_TAG=ci-testing \
+            $image_name
+        working-directory: ./compose/base-images
+      - name: Build galaxy-cluster-base
+        env:
+          image_name: galaxy-cluster-base
+        run: |
+          docker buildx build  \
+            --output "type=image,name=quay.io/bgruening/$image_name:ci-testing" \
+            --build-arg IMAGE_TAG=ci-testing \
+            $image_name
+        working-directory: ./compose/base-images
+      - name: Run tests for the first time
+        if: steps.run_check.outputs.run
+        run: |
+          export IMAGE_TAG=ci-testing
+          export COMPOSE_DOCKER_CLI_BUILD=1
+          export DOCKER_BUILDKIT=1
+          export ${{ matrix.infrastructure.env }}
+          export TIMEOUT=${{ matrix.test.timeout }}
+          docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} config
+          env
+          for i in 1 2; do
+            echo "Running test - try \#$i"
+            set +e
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} build --build-arg IMAGE_TAG=ci-testing --build-arg GALAXY_REPO=https://github.com/andreassko/galaxy
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
+            test_exit_code=$?
+            error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
+            if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
+              echo "Test failed..";
+              echo "Removing export directory";
+              sudo rm -rf export
+              continue;
+            else
+              exit $test_exit_code;
+            fi
+          done;
+          exit 1
+        shell: bash
+        working-directory: ./compose
+        continue-on-error: false
+      - name: Allow upload-artifact read access
+        if: failure()
+        run: sudo chmod -R +r ./compose/export/galaxy/database
+      - name: Save artifacts for debugging a failed test
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_first-run
+          path: ./compose/export/galaxy/database
+      - name: Clean up after first run
+        if: matrix.test.second_run == 'true'
+        run: |
+          sudo rm -rf export/postgres
+          sudo rm -rf export/galaxy/database
+        working-directory: ./compose
+      - name: Run tests a second time
+        if: matrix.test.second_run == 'true' && steps.run_check.run
+        run: |
+          export IMAGE_TAG=ci-testing
+          export COMPOSE_DOCKER_CLI_BUILD=1
+          export DOCKER_BUILDKIT=1
+          export ${{ matrix.infrastructure.env }}
+          export TIMEOUT=${{ matrix.test.timeout }}
+          for i in 1 2; do
+            echo "Running test - try \#$i"
+            set +e
+            docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
+            test_exit_code=$?
+            error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
+            if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
+              echo "Test failed..";
+              echo "Removing export directory";
+              sudo rm -rf export
+              continue;
+            else
+              exit $test_exit_code;
+            fi
+          done;
+          exit 1
+        shell: bash
+        working-directory: ./compose
+        continue-on-error: false
+      - name: Allow upload-artifact read access
+        if: failure()
+        run: sudo chmod -R +r ./compose/export/galaxy/database
+      - name: Save artifacts for debugging a failed test
+        uses: actions/upload-artifact@v1
+        if: failure() && matrix.test.second_run == 'true'
+        with:
+          name: ${{ matrix.infrastructure.name }}_${{ matrix.test.name }}_second-run
+          path: ./compose/export/galaxy/database


### PR DESCRIPTION
The current CI is only running when pushing to a branch, so we can't easily tell if a PR would pass all tests. As the main CI workflow pushes to a registry (to make local debugging and continuous development on a branch easier), we also can't just reuse the whole
concept for PRs.
This new pull-request workflow fixes this for now (though not perfectly) by building and testing in the same job (so no need to share data between runners). This is not really efficient, as we build all the containers for each and every test, however it is the simplest and most straightforward solution for now.

**Some other enhancements:**
* Remove the export-folder when retrying a test. This is needed for tests like creating a new user (currently on retry, the test would obviously fail with a `user already exists`)
* Fix retry logic of building and pushing containers: a `set +e` was missing, so the step would immediately fail instead of retrying..

**One small side note:**
We need to stay with the v1 of the  `upload-artifact` actions, as the new one has problems with some path names of Conda: `Artifact path is not valid: /jobs_directory/000/2/conda-metadata-env/man/man3/App::Cpan.3. Contains character: ":". Invalid characters include: ",:,<,>,|,*,?.`