### PR TITLE
Fix CI artifacts & retry more often

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -242,6 +242,8 @@ jobs:
           env
           for i in 1 2; do
             echo "Running test - try \#$i"
+            echo "Removing export directory if existent";
+            sudo rm -rf export
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} pull
             set +e
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
@@ -250,8 +252,6 @@ jobs:
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
-              echo "Removing export directory";
-              sudo rm -rf export
               continue;
             else
               exit $test_exit_code;
@@ -285,6 +285,8 @@ jobs:
           export TIMEOUT=${{ matrix.test.timeout }}
           for i in 1 2; do
             echo "Running test - try \#$i"
+            echo "Removing export directory if existent";
+            sudo rm -rf export
             set +e
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
@@ -292,8 +294,6 @@ jobs:
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
-              echo "Removing export directory";
-              sudo rm -rf export
               continue;
             else
               exit $test_exit_code;

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           image_name: galaxy-container-base
         run: |
-          for i in 1 2; do
+          for i in {1..4}; do
             set +e
             docker buildx build  \
             --output "type=image,name=${{ secrets.docker_registry }}/${{ secrets.docker_registry_username }}/$image_name:${{ steps.image_tag.outputs.image_tag }},push=true" \
@@ -61,7 +61,7 @@ jobs:
         env:
           image_name: galaxy-cluster-base
         run: |
-          for i in 1 2; do
+          for i in {1..4}; do
             set +e
             docker buildx build  \
             --output "type=image,name=${{ secrets.docker_registry }}/${{ secrets.docker_registry_username }}/$image_name:${{ steps.image_tag.outputs.image_tag }},push=true" \
@@ -112,7 +112,7 @@ jobs:
           buildx-version: v0.3.1
       - name: Run Buildx
         run: |
-          for i in 1 2; do
+          for i in {1..4}; do
             set +e
             docker buildx build \
             --output "type=image,name=${{ secrets.docker_registry }}/${{ secrets.docker_registry_username }}/${{ matrix.image.name }}:${{ steps.image_tag.outputs.image_tag }},push=true" \
@@ -240,7 +240,7 @@ jobs:
           export TIMEOUT=${{ matrix.test.timeout }}
           docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} config
           env
-          for i in 1 2; do
+          for i in {1..4}; do
             echo "Running test - try \#$i"
             echo "Removing export directory if existent";
             sudo rm -rf export
@@ -283,7 +283,7 @@ jobs:
           export DOCKER_REGISTRY_USERNAME=${{ secrets.docker_registry_username }}
           export ${{ matrix.infrastructure.env }}
           export TIMEOUT=${{ matrix.test.timeout }}
-          for i in 1 2; do
+          for i in {1..4}; do
             echo "Running test - try \#$i"
             echo "Removing export directory if existent";
             sudo rm -rf export

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -130,7 +130,7 @@ jobs:
           export TIMEOUT=${{ matrix.test.timeout }}
           docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} config
           env
-          for i in 1 2; do
+          for i in {1..4}; do
             echo "Running test - try \#$i"
             echo "Removing export directory if existent";
             sudo rm -rf export
@@ -174,7 +174,7 @@ jobs:
           export DOCKER_BUILDKIT=1
           export ${{ matrix.infrastructure.env }}
           export TIMEOUT=${{ matrix.test.timeout }}
-          for i in 1 2; do
+          for i in {1..4}; do
             echo "Running test - try \#$i"
             echo "Removing export directory if existent";
             sudo rm -rf export

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -132,6 +132,8 @@ jobs:
           env
           for i in 1 2; do
             echo "Running test - try \#$i"
+            echo "Removing export directory if existent";
+            sudo rm -rf export
             set +e
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} build --build-arg IMAGE_TAG=ci-testing --build-arg GALAXY_REPO=https://github.com/andreassko/galaxy
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
@@ -140,8 +142,6 @@ jobs:
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} down
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
-              echo "Removing export directory";
-              sudo rm -rf export
               continue;
             else
               exit $test_exit_code;
@@ -176,14 +176,14 @@ jobs:
           export TIMEOUT=${{ matrix.test.timeout }}
           for i in 1 2; do
             echo "Running test - try \#$i"
+            echo "Removing export directory if existent";
+            sudo rm -rf export
             set +e
             docker-compose ${{ matrix.infrastructure.files }} ${{ matrix.test.files }} up ${{ matrix.infrastructure.options }} --exit-code-from ${{ matrix.test.exit-from }}
             test_exit_code=$?
             error_exit_codes_count=$(expr $(docker ps -a --filter exited=1 | wc -l) - 1)
             if [ $error_exit_codes_count != 0 ] || [ $test_exit_code != 0 ] ; then
               echo "Test failed..";
-              echo "Removing export directory";
-              sudo rm -rf export
               continue;
             else
               exit $test_exit_code;


### PR DESCRIPTION
:bug: After https://github.com/bgruening/docker-galaxy-stable/pull/555 the export folder would be removed on every test fail, so the upload-artifacts didn't have any artifacts to save. This change will place the remove command before every test-run, so every test starts from a clean folder, while old artifacts can still be uploaded after all retries have failed.

:green_heart: Also, as some tests are a bit flaky and can still fail after the second try, I'm pushing the retry limit to four, which should hopefully fix some flaky CI runs..