### PR TITLE
[20.05] several bug fixes

### DIFF
--- a/galaxy/install_tools_wrapper.sh
+++ b/galaxy/install_tools_wrapper.sh
@@ -27,7 +27,12 @@ else
     done
 
     echo "starting Galaxy"
-    sudo -E -u galaxy unset $SUDO_UID; ./run.sh -d $install_log --pidfile galaxy_install.pid --http-timeout 3000
+    # Unset SUDO_* vars otherwise conda run chown based on that
+    sudo -E -u galaxy -- bash -c "unset SUDO_UID; \
+        unset SUDO_GID; \
+        unset SUDO_COMMAND; \
+        unset SUDO_USER; \
+        ./run.sh -d $install_log --pidfile galaxy_install.pid --http-timeout 3000"
 
     galaxy_install_pid=`cat galaxy_install.pid`
     galaxy-wait -g http://localhost:$PORT -v --timeout 120

--- a/galaxy/startup.sh
+++ b/galaxy/startup.sh
@@ -124,7 +124,7 @@ if [[ ! -z $LOAD_GALAXY_CONDITIONAL_DEPENDENCIES ]]
     then
         echo "Installing optional dependencies in galaxy virtual environment..."
         : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
-        GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))")
+        GALAXY_CONDITIONAL_DEPENDENCIES=$(PYTHONPATH=lib python -c "import galaxy.dependencies; print('\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE')))")
         [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -q -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}"
 fi
 


### PR DESCRIPTION
So I found a few bugs in 20.05 while playing with the GGA flavor:
- when the admin user gets updated (=each time install-tools is called), it hashes the password with pbkdf2 instead of sha1 as is configured in docker-galaxy-stable by default, which breaks the proftpd auth.
Fixed in https://github.com/galaxyproject/ansible-galaxy-extras/commit/e47436c941c5394aa6c09632d10df371ed6bcf68
- a problem with auth_conf.xml testing, fixed in https://github.com/galaxyproject/ansible-galaxy-extras/pull/243/commits/475f37f2ddf88c7592a2c9da26da929211842330
- conda envs created with `install-tools` were owned by root instead of galaxy, fixed in https://github.com/bgruening/docker-galaxy-stable/commit/55d049090e23bc9a5667f52beccc1fc89c7ca823
- there was a line of python2 code, fixed in https://github.com/galaxyproject/ansible-galaxy-extras/pull/243/commits/f1d3684ddbc1b7ea1756a237fba56c8e46cab066 and https://github.com/bgruening/docker-galaxy-stable/commit/acb93e2d9df42db8c8fc3a2c218f16d19ccbb4af

There is a chicken & egg thing for https://github.com/galaxyproject/ansible-galaxy-extras/pull/243 which is red until this PR is merged