### PR TITLE
Fix corrupted conda packages

### DIFF
--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -225,7 +225,6 @@ RUN mkdir -p /shed_tools $EXPORT_DIR/ftp/ \
     && find $GALAXY_ROOT/ -name '*.pyc' -delete | true \
     && find /usr/lib/ -name '*.pyc' -delete | true \
     && find /var/log/ -name '*.log' -delete | true \
-    && find $GALAXY_CONDA_PREFIX/ -name '*.pyc' -delete | true \
     && find $GALAXY_VIRTUAL_ENV -name '*.pyc' -delete | true \
     && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
 

--- a/galaxy/Dockerfile
+++ b/galaxy/Dockerfile
@@ -134,7 +134,6 @@ RUN curl -s -L https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_6
     # cleanup dance
     && find $GALAXY_ROOT -name '*.pyc' -delete | true \
     && find /usr/lib/ -name '*.pyc' -delete | true \
-    && find $GALAXY_CONDA_PREFIX/ -name '*.pyc' -delete | true \
     && find $GALAXY_VIRTUAL_ENV -name '*.pyc' -delete | true \
     && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
 
@@ -153,7 +152,6 @@ RUN mkdir $GALAXY_ROOT \
     # cleanup dance
     && find $GALAXY_ROOT -name '*.pyc' -delete | true \
     && find /usr/lib/ -name '*.pyc' -delete | true \
-    && find $GALAXY_CONDA_PREFIX/ -name '*.pyc' -delete | true \
     && find $GALAXY_VIRTUAL_ENV -name '*.pyc' -delete | true \
     && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
 
@@ -171,7 +169,6 @@ RUN apt update -qq && apt install --no-install-recommends -y ansible dirmngr gpg
     # cleanup dance
     && find $GALAXY_ROOT/ -name '*.pyc' -delete | true \
     && find /usr/lib/ -name '*.pyc' -delete | true \
-    && find $GALAXY_CONDA_PREFIX/ -name '*.pyc' -delete | true \
     && find $GALAXY_VIRTUAL_ENV -name '*.pyc' -delete | true \
     && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
 


### PR DESCRIPTION
Playing with 20.05, I found another problem: while installing new tools, some conda install fail with something like this:

```
CondaVerificationError: The package for certifi located at /tool_deps/_conda/pkgs/certifi-2020.6.20-py37hc8dfbb8_0
appears to be corrupted. The path 'lib/python3.7/site-packages/certifi/__pycache__/__init__.cpython-37.pyc'
specified in the package manifest cannot be found.
```
=> it produces empty mulled envs

I think it comes from the line I delete here ([introduced in 19.05](https://github.com/bgruening/docker-galaxy-stable/commit/1bae6039dc5db39bb8cac8006b0414bdd4429ffe))

= it deletes pyc files from downloaded pkgs, and conda doesn't like it when using these packages later

I'm not sure if it saved a lot of space, probably not I guess.