### PR TITLE
In compose: make the galaxy server depend on it's configurator

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     depends_on:
       - postgres
       - rabbitmq
+      - galaxy-configurator
     networks:
       - galaxy
   # The galaxy-configurator is responsible for the whole configuration of


### PR DESCRIPTION
This may fix the occasional `docker-compose up` failure I've seen complaining about the server not finding uwsgi in the venv bin directory?
Since I did this, I have not seen it happen - it was an occasional oddity,
